### PR TITLE
Modify the PgConnection class

### DIFF
--- a/orm_lib/src/postgresql_impl/test/test1.cc
+++ b/orm_lib/src/postgresql_impl/test/test1.cc
@@ -120,5 +120,15 @@ int main()
                                 std::cerr << "error:" << e.base().what() << std::endl;
                             },
                             "default");
+    *clientPtr << "select t2,t9 from ttt where t7=2" >> [](const Result &r) {
+        std::cout << r.size() << " rows selected!" << std::endl;
+        for (auto row : r)
+        {
+            std::cout << row["t9"].as<std::string>() << std::endl;
+            std::cout << row["t2"].as<int>() << std::endl;
+        }
+    } >> [](const DrogonDbException &e) {
+        std::cerr << "error:" << e.base().what() << std::endl;
+    };
     getchar();
 }


### PR DESCRIPTION
Use the PQSendQuery() function instead of the  PQsendQueryParams() function when the parameter number is 0.