### PR TITLE
Use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/trantor ${PROJECT_SOURCE_DIR}/lib/inc ${PROJECT_SOURCE_DIR}/orm_lib/inc)
 
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)
+
 #jsoncpp
 find_package (Jsoncpp REQUIRED)
 include_directories(${JSONCPP_INCLUDE_DIRS})
@@ -102,7 +103,7 @@ if (SQLITE3_FOUND)
   set(USE_ORM TRUE)
 endif()
 
-message(STATUS ${DIR_SRCS})
+#message(STATUS ${DIR_SRCS})
 
 if(CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE Release)
@@ -117,6 +118,7 @@ add_custom_target(makeVersion)
 add_custom_command(TARGET makeVersion
         COMMAND ${PROJECT_SOURCE_DIR}/get_version.sh
         ARGS ${PROJECT_SOURCE_DIR}/lib/inc/drogon/version.h
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         VERBATIM )
 
 add_subdirectory(examples)

--- a/drogon_ctl/templates/cmake.csp
+++ b/drogon_ctl/templates/cmake.csp
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required (VERSION 3.2)
 Project({{ProjectName}})
 
 link_directories(/usr/local/lib)
@@ -15,7 +15,6 @@ IF (CMAKE_SYSTEM_NAME MATCHES "Linux")
         MESSAGE(STATUS "c++14")
     else()
         set(CMAKE_CXX_STD_FLAGS c++17)
-        set(DR_DEFS "USE_STD_ANY")
         MESSAGE(STATUS "c++17")
     endif()
 else()
@@ -29,7 +28,7 @@ endif()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -std=${CMAKE_CXX_STD_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -std=${CMAKE_CXX_STD_FLAGS}")
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake_modules/)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)
 
 #jsoncpp
 find_package (Jsoncpp REQUIRED)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,5 +30,5 @@ add_executable(pipeline_test simple_example_test/HttpPipelineTest.cc)
 
 add_custom_command(TARGET webapp POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                   ${CMAKE_SOURCE_DIR}/config.example.json ${CMAKE_SOURCE_DIR}/drogon.jpg 
-                   ${CMAKE_SOURCE_DIR}/trantor/trantor/tests/server.pem $<TARGET_FILE_DIR:webapp>)
+                   ${PROJECT_SOURCE_DIR}/config.example.json ${PROJECT_SOURCE_DIR}/drogon.jpg 
+                   ${PROJECT_SOURCE_DIR}/trantor/trantor/tests/server.pem $<TARGET_FILE_DIR:webapp>)


### PR DESCRIPTION
Fix #93
It's better to use `set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)` 