### PR TITLE
uses default constructor of string_view to reset _statusMessage

### DIFF
--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -404,7 +404,7 @@ void HttpResponseImpl::clear()
 {
     _statusCode = kUnknown;
     _v = kHttp11;
-    _statusMessage = nullptr;
+    _statusMessage = string_view{};
     _fullHeaderString.reset();
     _headers.clear();
     _cookies.clear();


### PR DESCRIPTION
Fix to the following warning on GCC 9.1 on Arch Linux:

```
/home/mwo2/drogon/lib/src/HttpResponseImpl.cc: In member function ‘virtual void drogon::HttpResponseImpl::clear()’:
/home/mwo2/drogon/lib/src/HttpResponseImpl.cc:407:22: warning: null argument where non-null required (argument 2) [-Wnonnull]
  407 |     _statusMessage = nullptr;
      |                      ^~~~~~~
```