### PR TITLE
cmake: use export namespace for Drogon::Drogon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ lib/inc/drogon/config.h
 html/
 latex/
 .vscode
+*.kdev4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,4 +441,5 @@ install(
 # Install the export set for use with the install-tree
 install(EXPORT DrogonTargets
         DESTINATION "${INSTALL_DROGON_CMAKE_DIR}"
+        NAMESPACE Drogon::
         COMPONENT dev)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD ${DROGON_CXX_STAND
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 
-add_dependencies(drogon makeVersion)
+add_dependencies(${PROJECT_NAME} makeVersion)
 
 if(PostgreSQL_FOUND OR MYSQL_FOUND OR SQLITE3_FOUND)
   if(PostgreSQL_FOUND)
@@ -344,7 +344,7 @@ endif()
 
 # Installation
 
-install(TARGETS drogon
+install(TARGETS ${PROJECT_NAME}
         EXPORT DrogonTargets
         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT lib)
 

--- a/cmake/templates/DrogonConfig.cmake.in
+++ b/cmake/templates/DrogonConfig.cmake.in
@@ -9,8 +9,6 @@
 
 @PACKAGE_INIT@
 
-add_library(Drogon::Drogon INTERFACE IMPORTED GLOBAL)
-
 if(NOT TRANTOR_FOUND)
 # find trantor
   find_package(Trantor REQUIRED)
@@ -19,14 +17,13 @@ endif()
 # Our library dependencies (contains definitions for IMPORTED targets)
 
 get_filename_component(DROGON_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-if(NOT TARGET drogon)
+if(NOT TARGET Drogon::Drogon)
   include("${DROGON_CMAKE_DIR}/DrogonTargets.cmake")
+  set_target_properties(Drogon::drogon PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(Drogon::Drogon ALIAS Drogon::drogon)
 endif()
 
-# These are IMPORTED targets created by DrogonTargets.cmake
-target_link_libraries(Drogon::Drogon INTERFACE drogon)
-
-get_target_property(DROGON_INCLUDE_DIRS drogon INTERFACE_INCLUDE_DIRECTORIES)
-set(DROGON_LIBRARIES drogon)
+get_target_property(DROGON_INCLUDE_DIRS Drogon::Drogon INTERFACE_INCLUDE_DIRECTORIES)
+set(DROGON_LIBRARIES Drogon::Drogon)
 set(DROGON_EXECUTABLE drogon_ctl)
 set(DROGON_FOUND TRUE)

--- a/drogon_ctl/CMakeLists.txt
+++ b/drogon_ctl/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(_drogon_ctl
                cmd.cc
                create.cc
                create_view.cc)
-target_link_libraries(_drogon_ctl drogon)
+target_link_libraries(_drogon_ctl ${PROJECT_NAME})
 file(GLOB SCP_LIST ${CMAKE_CURRENT_SOURCE_DIR}/templates/*.csp)
 foreach(cspFile ${SCP_LIST})
   message(STATUS "cspFile:" ${cspFile})
@@ -37,7 +37,7 @@ foreach(cspFile ${SCP_LIST})
   set(TEMPL_SRC ${TEMPL_SRC} ${classname}.cc)
 endforeach()
 add_executable(drogon_ctl ${ctl_sources} ${TEMPL_SRC})
-target_link_libraries(drogon_ctl PRIVATE drogon)
+target_link_libraries(drogon_ctl PRIVATE ${PROJECT_NAME})
 target_include_directories(drogon_ctl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(drogon_ctl
                  trantor

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_libraries(drogon)
+link_libraries(${PROJECT_NAME})
 
 file(GLOB SCP_LIST ${CMAKE_CURRENT_SOURCE_DIR}/simple_example/*.csp)
 foreach(cspFile ${SCP_LIST})

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_libraries(drogon)
+link_libraries(${PROJECT_NAME})
 
 add_executable(cache_map_test CacheMapTest.cc)
 add_executable(cache_map_test2 CacheMapTest2.cc)

--- a/orm_lib/src/mysql_impl/test/CMakeLists.txt
+++ b/orm_lib/src/mysql_impl/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_libraries(drogon)
+link_libraries(${PROJECT_NAME})
 
 add_executable(mysql_test1 test1.cc)
 

--- a/orm_lib/src/postgresql_impl/test/CMakeLists.txt
+++ b/orm_lib/src/postgresql_impl/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_libraries(drogon)
+link_libraries(${PROJECT_NAME})
 
 add_executable(pg_test1 test1.cc)
 add_executable(pg_test2 test2.cc)

--- a/orm_lib/src/sqlite3_impl/test/CMakeLists.txt
+++ b/orm_lib/src/sqlite3_impl/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_libraries(drogon)
+link_libraries(${PROJECT_NAME})
 
 add_executable(sqlite3_test1 test1.cc Groups.cc)
 

--- a/orm_lib/tests/CMakeLists.txt
+++ b/orm_lib/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_libraries(drogon)
+link_libraries(${PROJECT_NAME})
 
 add_executable(db_test db_test.cc Users.cc)
 


### PR DESCRIPTION
Same idea as in #254, but it actually works this time 😃. This PR also cleans up the inconsistent use of `drogon` and `${PROJECT_NAME}`.