### PR TITLE
fix url decode

### DIFF
--- a/examples/simple_example/api_v1_ApiTest.cc
+++ b/examples/simple_example/api_v1_ApiTest.cc
@@ -400,7 +400,8 @@ void ApiTest::formTest(const HttpRequestPtr &req,
     ret["k2"] = parameters["k2"];
     ret["k3"] = parameters["k3"];
 
-    if (parameters["k1"] == "1" && parameters["k2"] == "安" && parameters["k3"] == "test@example.com")
+    if (parameters["k1"] == "1" && parameters["k2"] == "安" &&
+        parameters["k3"] == "test@example.com")
     {
         ret["result"] = "ok";
     }

--- a/examples/simple_example/api_v1_ApiTest.cc
+++ b/examples/simple_example/api_v1_ApiTest.cc
@@ -396,7 +396,11 @@ void ApiTest::formTest(const HttpRequestPtr &req,
 {
     auto parameters = req->getParameters();
     Json::Value ret;
-    if (parameters["k1"] == "1" && parameters["k2"] == "安")
+    ret["k1"] = parameters["k1"];
+    ret["k2"] = parameters["k2"];
+    ret["k3"] = parameters["k3"];
+
+    if (parameters["k1"] == "1" && parameters["k2"] == "安" && parameters["k3"] == "test@example.com")
     {
         ret["result"] = "ok";
     }

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -901,6 +901,7 @@ void doTest(const HttpClientPtr &client,
     req->setPath("/api/v1/apitest/form");
     req->setParameter("k1", "1");
     req->setParameter("k2", "安");
+    req->setParameter("k3", "test@example.com");
     client->sendRequest(req,
                         [=](ReqResult result, const HttpResponsePtr &resp) {
                             if (result == ReqResult::Ok)

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -506,8 +506,8 @@ std::string urlDecode(const char *begin, const char *end)
                     }
                     hex = x1 * 16 + x2;
 
-		    result += char(hex);
-		    i += 2;
+                    result += char(hex);
+                    i += 2;
                 }
                 else
                 {

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -505,22 +505,9 @@ std::string urlDecode(const char *begin, const char *end)
                         x2 = x2 - 'A' + 10;
                     }
                     hex = x1 * 16 + x2;
-                    if (!((hex >= 48 && hex <= 57) ||   // 0-9
-                          (hex >= 97 && hex <= 122) ||  // a-z
-                          (hex >= 65 && hex <= 90) ||   // A-Z
-                          //[$-_.+!*'(),]  [$&+,/:;?@]
-                          hex == 0x21 || hex == 0x24 || hex == 0x26 ||
-                          hex == 0x27 || hex == 0x28 || hex == 0x29 ||
-                          hex == 0x2a || hex == 0x2b || hex == 0x2c ||
-                          hex == 0x2d || hex == 0x2e || hex == 0x2f ||
-                          hex == 0x3A || hex == 0x3B || hex == 0x3f ||
-                          hex == 0x40 || hex == 0x5f))
-                    {
-                        result += char(hex);
-                        i += 2;
-                    }
-                    else
-                        result += '%';
+
+		    result += char(hex);
+		    i += 2;
                 }
                 else
                 {


### PR DESCRIPTION
simple fix to enable getParameters to retrive original input.

before fix,

input: 123@example.com
got: 123%40example.com

every char should be unescaped if we can.  remove the if-condition.