### PR TITLE
Fix size_t underflow

### DIFF
--- a/drogon_ctl/create_controller.cc
+++ b/drogon_ctl/create_controller.cc
@@ -194,11 +194,11 @@ void create_controller::newWebsockControllerHeaderFile(
     file << "    //WS_PATH_ADD(\"/path\",\"filter1\",\"filter2\",...);\n";
     file << "    WS_PATH_LIST_END\n";
     file << "};\n";
-    do
+    while (namespaceCount > 0)
     {
         --namespaceCount;
         file << "}\n";
-    } while (namespaceCount > 0);
+    }
 }
 void create_controller::newWebsockControllerSourceFile(
     std::ofstream &file,
@@ -283,11 +283,11 @@ void create_controller::newHttpControllerHeaderFile(
             "std::function<void (const HttpResponsePtr &)> &&callback,double "
             "p1,int p2) const;\n";
     file << "};\n";
-    do
+    while (namespaceCount > 0)
     {
         --namespaceCount;
         file << "}\n";
-    } while (namespaceCount > 0);
+    }
 }
 void create_controller::newHttpControllerSourceFile(
     std::ofstream &file,

--- a/drogon_ctl/create_controller.cc
+++ b/drogon_ctl/create_controller.cc
@@ -126,11 +126,11 @@ void create_controller::newSimpleControllerHeaderFile(
             "path\",\"filter1\",\"filter2\",HttpMethod1,HttpMethod2...);\n";
     file << "    PATH_LIST_END\n";
     file << "};\n";
-    do
+    while (namespaceCount > 0)
     {
         --namespaceCount;
         file << "}\n";
-    } while (namespaceCount > 0);
+    }
 }
 void create_controller::newSimpleControllerSourceFile(
     std::ofstream &file,

--- a/test.sh
+++ b/test.sh
@@ -57,8 +57,16 @@ cd drogon_test/controllers
 drogon_ctl create controller Test::SimpleCtrl
 drogon_ctl create controller -h Test::HttpCtrl
 drogon_ctl create controller -w Test::WebsockCtrl
+drogon_ctl create controller SimpleCtrl
+drogon_ctl create controller -h HttpCtrl
+drogon_ctl create controller -w WebsockCtrl
 
 if [ ! -f "Test_SimpleCtrl.h" -o ! -f "Test_SimpleCtrl.cc" -o ! -f "Test_HttpCtrl.h" -o ! -f "Test_HttpCtrl.cc" -o ! -f "Test_WebsockCtrl.h" -o ! -f "Test_WebsockCtrl.cc" ];then
+    echo "Failed to create controllers"
+    exit -1
+fi
+
+if [ ! -f "SimpleCtrl.h" -o ! -f "SimpleCtrl.cc" -o ! -f "HttpCtrl.h" -o ! -f "HttpCtrl.cc" -o ! -f "WebsockCtrl.h" -o ! -f "WebsockCtrl.cc" ];then
     echo "Failed to create controllers"
     exit -1
 fi


### PR DESCRIPTION
This fixes abnormal behaviour when controller without namespace
is being created.

When I ran `drogon_ctl` to create controller, as presented in wiki, the program was stuck appending multiple closing `}`s to the header file being created.
The same but ran with controller class name prepended with namespace worked fine.

The bug was simply caused by the loop checking for `namespaceCount` unsigned variable to be positive after it was decremented, that with `namespaceCount` being 0 leads to unsigned int underflow.