### PR TITLE
Add option to disable setting the 404 status code

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -108,8 +108,11 @@ class HttpAppFramework : public trantor::NonCopyable
      * @param resp is the object set to 404 response
      * After calling this method, the resp object is returned
      * by the HttpResponse::newNotFoundResponse() method.
+     * @param set404 if true, the status code of the resp will
+     * be set to 404 automatically
      */
-    virtual HttpAppFramework &setCustom404Page(const HttpResponsePtr &resp) = 0;
+    virtual HttpAppFramework &setCustom404Page(const HttpResponsePtr &resp,
+                                               bool set404 = true) = 0;
 
     /// Get the plugin object registered in the framework
     /**

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -70,10 +70,13 @@ class HttpAppFrameworkImpl : public HttpAppFramework
         const std::vector<internal::HttpConstraint> &filtersAndMethods =
             std::vector<internal::HttpConstraint>{}) override;
 
-    virtual HttpAppFramework &setCustom404Page(
-        const HttpResponsePtr &resp) override
+    virtual HttpAppFramework &setCustom404Page(const HttpResponsePtr &resp,
+                                               bool set404) override
     {
-        resp->setStatusCode(k404NotFound);
+        if (set404)
+        {
+            resp->setStatusCode(k404NotFound);
+        }
         _custom404 = resp;
         return *this;
     }


### PR DESCRIPTION
For SPA applications, it is usually recommended to send the `index.html` and handle the 404 in the javascript code, see [here](https://router.vuejs.org/guide/essentials/history-mode.html). This is already easy to implement in drogon; however, before this PR, the status code of the response was always set to 404 automatically. With this PR, this behavior can be turned off.