### PR TITLE
Add type conversion methods to the HttpRequest and HttpResponse classes

### DIFF
--- a/examples/simple_example/api_v1_ApiTest.cc
+++ b/examples/simple_example/api_v1_ApiTest.cc
@@ -375,9 +375,9 @@ void ApiTest::get2(const HttpRequestPtr &req,
 }
 
 void ApiTest::jsonTest(const HttpRequestPtr &req,
-                       std::function<void(const HttpResponsePtr &)> &&callback)
+                       std::function<void(const HttpResponsePtr &)> &&callback,
+                       std::shared_ptr<Json::Value> &&json)
 {
-    auto json = req->getJsonObject();
     Json::Value ret;
     if (json)
     {
@@ -387,7 +387,7 @@ void ApiTest::jsonTest(const HttpRequestPtr &req,
     {
         ret["result"] = "bad";
     }
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    auto resp = HttpResponse::newCustomHttpResponse(ret);
     callback(resp);
 }
 

--- a/examples/simple_example/api_v1_ApiTest.h
+++ b/examples/simple_example/api_v1_ApiTest.h
@@ -55,7 +55,8 @@ class ApiTest : public drogon::HttpController<ApiTest>
     void rootPost(const HttpRequestPtr &req,
                   std::function<void(const HttpResponsePtr &)> &&callback);
     void jsonTest(const HttpRequestPtr &req,
-                  std::function<void(const HttpResponsePtr &)> &&callback);
+                  std::function<void(const HttpResponsePtr &)> &&callback,
+                  std::shared_ptr<Json::Value> &&json);
     void formTest(const HttpRequestPtr &req,
                   std::function<void(const HttpResponsePtr &)> &&callback);
     void attributesTest(

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -119,7 +119,16 @@ class Test : public HttpController<Test>
 using namespace std::placeholders;
 using namespace drogon;
 
-/// Some examples in the main function some common functions of drogon. In
+namespace drogon
+{
+template <>
+string_view fromRequest<string_view>(const HttpRequest &req)
+{
+    return req.body();
+}
+}  // namespace drogon
+
+/// Some examples in the main function show some common functions of drogon. In
 /// practice, we don't need such a lengthy main function.
 int main()
 {
@@ -142,8 +151,16 @@ int main()
         "/api/v1/handle2/{1}/{2}",
         [](const HttpRequestPtr &req,
            std::function<void(const HttpResponsePtr &)> &&callback,
-           int a,
-           float b) {
+           int a,    // here the `a` parameter is converted from the number 1
+                     // parameter in the path.
+           float b,  // here the `b` parameter is converted from the number 2
+                     // parameter in the path.
+           string_view &&body,  // here the `body` parameter is converted from
+                                // req->as<string_view>();
+           const std::shared_ptr<Json::Value>
+               &jsonPtr  // here the `jsonPtr` parameter is converted from
+                         // req->as<std::shared_ptr<Json::Value>>();
+        ) {
             HttpViewData data;
             data.insert("title", std::string("ApiTest::get"));
             std::unordered_map<std::string, std::string> para;
@@ -152,6 +169,8 @@ int main()
             data.insert("parameters", para);
             auto res = HttpResponse::newHttpViewResponse("ListParaView", data);
             callback(res);
+            LOG_DEBUG << body;
+            assert(!jsonPtr);
         });
 
     // Functor example

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -169,7 +169,7 @@ int main()
             data.insert("parameters", para);
             auto res = HttpResponse::newHttpViewResponse("ListParaView", data);
             callback(res);
-            LOG_DEBUG << body;
+            LOG_DEBUG << body.data();
             assert(!jsonPtr);
         });
 

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -164,14 +164,14 @@ void doTest(const HttpClientPtr &client,
     /// Post json
     Json::Value json;
     json["request"] = "json";
-    req = HttpRequest::newHttpJsonRequest(json);
+    req = HttpRequest::newCustomHttpRequest(json);
     req->setMethod(drogon::Post);
     req->setPath("/api/v1/apitest/json");
     client->sendRequest(req,
                         [=](ReqResult result, const HttpResponsePtr &resp) {
                             if (result == ReqResult::Ok)
                             {
-                                auto ret = resp->getJsonObject();
+                                std::shared_ptr<Json::Value> ret = *resp;
                                 if (ret && (*ret)["result"].asString() == "ok")
                                 {
                                     outputGood(req, isHttps);

--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -34,7 +34,7 @@ typedef std::shared_ptr<HttpRequest> HttpRequestPtr;
 
 /**
  * @brief This template is used to convert a request object to a custom
- * type of object. Users must specialize the template for a particular type.
+ * type object. Users must specialize the template for a particular type.
  */
 template <typename T>
 T fromRequest(const HttpRequest &req)
@@ -46,7 +46,7 @@ T fromRequest(const HttpRequest &req)
 
 /**
  * @brief This template is used to create a request object from a custom
- * type of object by calling the newCustomHttpRequest(). Users must specialize
+ * type object by calling the newCustomHttpRequest(). Users must specialize
  * the template for a particular type.
  */
 template <typename T>

--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <drogon/utils/string_view.h>
+#include <drogon/DrClassMap.h>
 #include <drogon/HttpTypes.h>
 #include <drogon/Session.h>
 #include <drogon/Attribute.h>
@@ -31,10 +32,76 @@ namespace drogon
 class HttpRequest;
 typedef std::shared_ptr<HttpRequest> HttpRequestPtr;
 
+/**
+ * @brief This template is used to convert a request object to a custom
+ * type of object. Users must specialize the template for a particular type.
+ */
+template <typename T>
+T fromRequest(const HttpRequest &req)
+{
+    LOG_ERROR << "You must specialize the fromRequest template for the type of "
+              << DrClassMap::demangle(typeid(T).name());
+    exit(1);
+}
+
+/**
+ * @brief This template is used to create a request object from a custom
+ * type of object by calling the newCustomHttpRequest(). Users must specialize
+ * the template for a particular type.
+ */
+template <typename T>
+HttpRequestPtr toRequest(T &&)
+{
+    LOG_ERROR << "You must specialize the toRequest template for the type of "
+              << DrClassMap::demangle(typeid(T).name());
+    exit(1);
+}
+
+template <>
+HttpRequestPtr toRequest(const Json::Value &pJson);
+template <>
+HttpRequestPtr toRequest(Json::Value &&pJson);
+template <>
+inline HttpRequestPtr toRequest(Json::Value &pJson)
+{
+    return toRequest((const Json::Value &)pJson);
+}
+
+template <>
+std::shared_ptr<Json::Value> fromRequest(const HttpRequest &req);
+
 /// Abstract class for webapp developer to get or set the Http request;
 class HttpRequest
 {
   public:
+    /**
+     * @brief This template enables implicit type conversion. For using this
+     * template, user must specialize the fromRequest template. For example a
+     * shared_ptr<Json::Value> specialization version is available above, so
+     * we can use the following code to get a json object:
+     * @code
+       std::shared_ptr<Json::Value> jsonPtr = *requestPtr;
+       @endcode
+     * With this template, user can use their favorite JSON library instead of
+     * the default jsoncpp library or convert the request to an object of any
+     * custom type.
+     */
+    template <typename T>
+    operator T() const
+    {
+        return fromRequest<T>(*this);
+    }
+
+    /**
+     * @brief This template enables explicit type conversion, see the above
+     * template.
+     */
+    template <typename T>
+    T as() const
+    {
+        return fromRequest<T>(*this);
+    }
+
     enum Version
     {
         kUnknown = 0,
@@ -282,9 +349,37 @@ class HttpRequest
     static HttpRequestPtr newFileUploadRequest(
         const std::vector<UploadFile> &files);
 
+    /**
+     * @brief Create a custom HTTP request object. For using this template,
+     * users must specialize the toRequest template.
+     */
+    template <typename T>
+    static HttpRequestPtr newCustomHttpRequest(T &&obj)
+    {
+        return toRequest(std::forward<T>(obj));
+    }
+
     virtual ~HttpRequest()
     {
     }
 };
+
+template <>
+inline HttpRequestPtr toRequest(const Json::Value &pJson)
+{
+    return HttpRequest::newHttpJsonRequest(pJson);
+}
+
+template <>
+inline HttpRequestPtr toRequest(Json::Value &&pJson)
+{
+    return HttpRequest::newHttpJsonRequest(std::move(pJson));
+}
+
+template <>
+inline std::shared_ptr<Json::Value> fromRequest(const HttpRequest &req)
+{
+    return req.getJsonObject();
+}
 
 }  // namespace drogon

--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <drogon/utils/string_view.h>
+#include <drogon/DrClassMap.h>
 #include <drogon/Cookie.h>
 #include <drogon/HttpTypes.h>
 #include <drogon/HttpViewData.h>
@@ -26,12 +27,73 @@ namespace drogon
 /// Abstract class for webapp developer to get or set the Http response;
 class HttpResponse;
 typedef std::shared_ptr<HttpResponse> HttpResponsePtr;
+
+/**
+ * @brief This template is used to convert a response object to a custom
+ * type of object. Users must specialize the template for a particular type.
+ */
+template <typename T>
+T fromResponse(const HttpResponse &resp)
+{
+    LOG_ERROR
+        << "You must specialize the fromResponse template for the type of "
+        << DrClassMap::demangle(typeid(T).name());
+    exit(1);
+}
+
+/**
+ * @brief This template is used to create a response object from a custom
+ * type of object by calling the newCustomHttpResponse(). Users must specialize
+ * the template for a particular type.
+ */
+template <typename T>
+HttpResponsePtr toResponse(T &&)
+{
+    LOG_ERROR << "You must specialize the toResponse template for the type of "
+              << DrClassMap::demangle(typeid(T).name());
+    exit(1);
+}
+template <>
+HttpResponsePtr toResponse(const Json::Value &pJson);
+template <>
+HttpResponsePtr toResponse(Json::Value &&pJson);
+template <>
+inline HttpResponsePtr toResponse(Json::Value &pJson)
+{
+    return toResponse((const Json::Value &)pJson);
+}
+
 class HttpResponse
 {
   public:
-    HttpResponse()
+    /**
+     * @brief This template enables automatic type conversion. For using this
+     * template, user must specialize the fromResponse template. For example a
+     * shared_ptr<Json::Value> specialization version is available above, so
+     * we can use the following code to get a json object:
+     * @code
+     *  std::shared_ptr<Json::Value> jsonPtr = *responsePtr;
+     *  @endcode
+     * With this template, user can use their favorite JSON library instead of
+     * the default jsoncpp library or convert the response to an object of any
+     * custom type.
+     */
+    template <typename T>
+    operator T() const
     {
+        return fromResponse<T>(*this);
     }
+
+    /**
+     * @brief This template enables explicit type conversion, see the above
+     * template.
+     */
+    template <typename T>
+    T as() const
+    {
+        return fromResponse<T>(*this);
+    }
+
     /// Get the status code such as 200, 404
     virtual HttpStatusCode statusCode() const = 0;
     HttpStatusCode getStatusCode() const
@@ -255,6 +317,16 @@ class HttpResponse
         const std::string &attachmentFileName = "",
         ContentType type = CT_NONE);
 
+    /**
+     * @brief Create a custom HTTP response object. For using this template,
+     * users must specialize the toResponse template.
+     */
+    template <typename T>
+    static HttpResponsePtr newCustomHttpResponse(T &&obj)
+    {
+        return toResponse(std::forward<T>(obj));
+    }
+
     virtual ~HttpResponse()
     {
     }
@@ -262,5 +334,21 @@ class HttpResponse
   private:
     virtual void setBody(const char *body, size_t len) = 0;
 };
+template <>
+inline HttpResponsePtr toResponse(const Json::Value &pJson)
+{
+    return HttpResponse::newHttpJsonResponse(pJson);
+}
 
+template <>
+inline HttpResponsePtr toResponse(Json::Value &&pJson)
+{
+    return HttpResponse::newHttpJsonResponse(std::move(pJson));
+}
+
+template <>
+inline std::shared_ptr<Json::Value> fromResponse(const HttpResponse &resp)
+{
+    return resp.getJsonObject();
+}
 }  // namespace drogon

--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -30,7 +30,7 @@ typedef std::shared_ptr<HttpResponse> HttpResponsePtr;
 
 /**
  * @brief This template is used to convert a response object to a custom
- * type of object. Users must specialize the template for a particular type.
+ * type object. Users must specialize the template for a particular type.
  */
 template <typename T>
 T fromResponse(const HttpResponse &resp)
@@ -43,7 +43,7 @@ T fromResponse(const HttpResponse &resp)
 
 /**
  * @brief This template is used to create a response object from a custom
- * type of object by calling the newCustomHttpResponse(). Users must specialize
+ * type object by calling the newCustomHttpResponse(). Users must specialize
  * the template for a particular type.
  */
 template <typename T>

--- a/lib/src/HttpRequestImpl.h
+++ b/lib/src/HttpRequestImpl.h
@@ -352,9 +352,16 @@ class HttpRequestImpl : public HttpRequest
 
     virtual const std::shared_ptr<Json::Value> jsonObject() const override
     {
-        parseParametersOnce();
+        // Not multi-thread safe but good, because we basically call this
+        // function in a single thread
+        if (!_flagForParsingJson)
+        {
+            _flagForParsingJson = true;
+            parseJson();
+        }
         return _jsonPtr;
     }
+
     virtual void setCustomContentTypeString(const std::string &type) override
     {
         _contentType = CT_NONE;
@@ -425,7 +432,10 @@ class HttpRequestImpl : public HttpRequest
             parseParameters();
         }
     }
+
+    void parseJson() const;
     mutable bool _flagForParsingParameters = false;
+    mutable bool _flagForParsingJson = false;
     HttpMethod _method;
     Version _version;
     std::string _path;

--- a/lib/src/HttpResponseImpl.h
+++ b/lib/src/HttpResponseImpl.h
@@ -286,8 +286,11 @@ class HttpResponseImpl : public HttpResponse
     void parseJson() const;
     virtual const std::shared_ptr<Json::Value> jsonObject() const override
     {
-        if (!_jsonPtr)
+        // Not multi-thread safe but good, because we basically call this
+        // function in a single thread
+        if (!_flagForParsingJson)
         {
+            _flagForParsingJson = true;
             parseJson();
         }
         return _jsonPtr;
@@ -366,7 +369,7 @@ class HttpResponseImpl : public HttpResponse
     mutable std::shared_ptr<std::string> _httpString;
     mutable std::string::size_type _datePos = std::string::npos;
     mutable int64_t _httpStringDate = -1;
-
+    mutable bool _flagForParsingJson = false;
     ContentType _contentType = CT_TEXT_HTML;
     string_view _contentTypeString =
         "Content-Type: text/html; charset=utf-8\r\n";


### PR DESCRIPTION
The purpose of this PR is to provide a compromise solution to resolve #249.

After this PR, users can use their favorite JSON library instead of the `jsoncpp` library. If the methods (jsonObject() etc) for `jsoncpp` are never called, no serialization or deserialization for it will occur, so there is no pay for changing the JSON library.

And as a  coproduct of this mean purpose, the ability to map an HttpRequest object to a custom type parameter in the HttpController handler parameters list is provided as well.