### PR TITLE
Fix compilation on alpine

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -902,7 +902,7 @@ class HttpAppFramework : public trantor::NonCopyable
     virtual HttpAppFramework &createDbClient(
         const std::string &dbType,
         const std::string &host,
-        const u_short port,
+        const unsigned short port,
         const std::string &databaseName,
         const std::string &userName,
         const std::string &password,

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -389,7 +389,7 @@ static void loadDbClients(const Json::Value &dbClients)
         auto isFast = client.get("is_fast", false).asBool();
         drogon::app().createDbClient(type,
                                      host,
-                                     (u_short)port,
+                                     (unsigned short)port,
                                      dbname,
                                      user,
                                      password,

--- a/lib/src/DbClientManager.h
+++ b/lib/src/DbClientManager.h
@@ -44,7 +44,7 @@ class DbClientManager : public trantor::NonCopyable
     }
     void createDbClient(const std::string &dbType,
                         const std::string &host,
-                        const u_short port,
+                        const unsigned short port,
                         const std::string &databaseName,
                         const std::string &userName,
                         const std::string &password,

--- a/lib/src/DbClientManagerSkipped.cc
+++ b/lib/src/DbClientManagerSkipped.cc
@@ -29,7 +29,7 @@ void DbClientManager::createDbClients(
 
 void DbClientManager::createDbClient(const std::string &dbType,
                                      const std::string &host,
-                                     const u_short port,
+                                     const unsigned short port,
                                      const std::string &databaseName,
                                      const std::string &userName,
                                      const std::string &password,

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -735,7 +735,7 @@ orm::DbClientPtr HttpAppFrameworkImpl::getFastDbClient(const std::string &name)
 HttpAppFramework &HttpAppFrameworkImpl::createDbClient(
     const std::string &dbType,
     const std::string &host,
-    const u_short port,
+    const unsigned short port,
     const std::string &databaseName,
     const std::string &userName,
     const std::string &password,

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -366,7 +366,7 @@ class HttpAppFrameworkImpl : public HttpAppFramework
     virtual HttpAppFramework &createDbClient(
         const std::string &dbType,
         const std::string &host,
-        const u_short port,
+        const unsigned short port,
         const std::string &databaseName,
         const std::string &userName,
         const std::string &password,

--- a/orm_lib/src/DbClientManager.cc
+++ b/orm_lib/src/DbClientManager.cc
@@ -87,7 +87,7 @@ void DbClientManager::createDbClients(
 
 void DbClientManager::createDbClient(const std::string &dbType,
                                      const std::string &host,
-                                     const u_short port,
+                                     const unsigned short port,
                                      const std::string &databaseName,
                                      const std::string &userName,
                                      const std::string &password,


### PR DESCRIPTION
Hi @an-tao,

`drogon` could not be **compiled** on `alpine`.

This is due to a _non standard_ alias, `u_short `.

This `PR` fixes `alpine` compilation by replacing  `u_short` with `unsigned short`.

Regards,