### PR TITLE
Explicitly set path to '/' for JSESSIONID cookie

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -564,14 +564,18 @@ void HttpAppFrameworkImpl::callCallback(
                 auto newResp = std::make_shared<HttpResponseImpl>(
                     *static_cast<HttpResponseImpl *>(resp.get()));
                 newResp->setExpiredTime(-1);  // make it temporary
-                newResp->addCookie("JSESSIONID", sessionPtr->sessionId());
+                auto jsessionid = Cookie("JSESSIONID", sessionPtr->sessionId());
+                jsessionid.setPath("/");
+                newResp->addCookie(std::move(jsessionid));
                 sessionPtr->hasSet();
                 callback(newResp);
                 return;
             }
             else
             {
-                resp->addCookie("JSESSIONID", sessionPtr->sessionId());
+                auto jsessionid = Cookie("JSESSIONID", sessionPtr->sessionId());
+                jsessionid.setPath("/");
+                resp->addCookie(std::move(jsessionid));
                 sessionPtr->hasSet();
                 callback(resp);
                 return;


### PR DESCRIPTION
Per [RFC-6265](https://tools.ietf.org/html/rfc6265)

> If the server omits the Path attribute, the user agent will use the "directory" of the request-uri's path component as the default value.

This will lead to `JSESSIONID` diverging between distinct endpoints, i.e. `/a/b` and `/foo/bar`.  By setting  `JSESSIONID` path to `"/"`, it will be set for all paths within the app.