### PR TITLE
Update for ORM time mapper

### DIFF
--- a/drogon_ctl/templates/model_cc.csp
+++ b/drogon_ctl/templates/model_cc.csp
@@ -124,7 +124,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
-                $$<<"            long t = timelocal(&stm);\n";
+                $$<<"            long t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
                 $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(t*1000000);\n";
                 $$<<"        }\n";
@@ -136,7 +136,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
-                $$<<"            size_t t = timelocal(&stm);\n";
+                $$<<"            size_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
                 $$<<"            if(*p=='.')\n";
                 $$<<"            {\n";
@@ -195,7 +195,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
-                $$<<"            long t = timelocal(&stm);\n";
+                $$<<"            long t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
                 $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(t*1000000);\n";
                 $$<<"        }\n";
@@ -207,7 +207,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
-                $$<<"            size_t t = timelocal(&stm);\n";
+                $$<<"            size_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
                 $$<<"            if(*p=='.')\n";
                 $$<<"            {\n";
@@ -277,7 +277,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
-                $$<<"            long t = timelocal(&stm);\n";
+                $$<<"            long t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
                 $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(t*1000000);\n";
                 $$<<"        }\n";
@@ -292,7 +292,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
-                $$<<"            size_t t = timelocal(&stm);\n";
+                $$<<"            size_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
                 $$<<"            if(*p=='.')\n";
                 $$<<"            {\n";
@@ -401,7 +401,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
-                $$<<"            long t = timelocal(&stm);\n";
+                $$<<"            long t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
                 $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(t*1000000);\n";
                 $$<<"        }\n";
@@ -416,7 +416,7 @@ const std::string &[[className]]::getColumnName(size_t index) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
-                $$<<"            size_t t = timelocal(&stm);\n";
+                $$<<"            size_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
                 $$<<"            if(*p=='.')\n";
                 $$<<"            {\n";
@@ -534,7 +534,7 @@ void [[className]]::updateByMasqueradedJson(const Json::Value &pJson,
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
-                $$<<"            long t = timelocal(&stm);\n";
+                $$<<"            long t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
                 $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(t*1000000);\n";
                 $$<<"        }\n";
@@ -549,7 +549,7 @@ void [[className]]::updateByMasqueradedJson(const Json::Value &pJson,
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
-                $$<<"            size_t t = timelocal(&stm);\n";
+                $$<<"            size_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
                 $$<<"            if(*p=='.')\n";
                 $$<<"            {\n";
@@ -661,7 +661,7 @@ void [[className]]::updateByJson(const Json::Value &pJson) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            strptime(daysStr.c_str(),\"%Y-%m-%d\",&stm);\n";
-                $$<<"            long t = timelocal(&stm);\n";
+                $$<<"            long t = mktime(&stm);\n";
  //               $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(::trantor::Date(946656000000000).after(daysNum*86400));\n";
                 $$<<"            "<<col.colValName_<<"_=std::make_shared<::trantor::Date>(t*1000000);\n";
                 $$<<"        }\n";
@@ -676,7 +676,7 @@ void [[className]]::updateByJson(const Json::Value &pJson) noexcept(false)
                 $$<<"            struct tm stm;\n";
                 $$<<"            memset(&stm,0,sizeof(stm));\n";
                 $$<<"            auto p = strptime(timeStr.c_str(),\"%Y-%m-%d %H:%M:%S\",&stm);\n";
-                $$<<"            size_t t = timelocal(&stm);\n";
+                $$<<"            size_t t = mktime(&stm);\n";
                 $$<<"            size_t decimalNum = 0;\n";
                 $$<<"            if(*p=='.')\n";
                 $$<<"            {\n";


### PR DESCRIPTION
The timelocal() function is equivalent to the POSIX standard function mktime(3). There is no reason to ever use it.
https://linux.die.net/man/3/timelocal

Using timelocal() produce compilation error