### PR TITLE
Add getHomePage to HttpAppFramework

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -972,6 +972,13 @@ class HttpAppFramework : public trantor::NonCopyable
      */
     virtual HttpAppFramework &setHomePage(const std::string &homePageFile) = 0;
 
+    /// Get homepage, default is "index.html"
+    /**
+     * @note
+     * This method must be called after the framework has been run.
+     */
+    virtual const std::string &getHomePage() const = 0;
+
     /// Get a database client by name
     /**
      * @note

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -298,7 +298,7 @@ class HttpAppFrameworkImpl : public HttpAppFramework
         homePageFile_ = homePageFile;
         return *this;
     }
-    const std::string &getHomePage() const
+    const std::string &getHomePage() const override
     {
         return homePageFile_;
     }


### PR DESCRIPTION
Add getHomePage to HttpAppFramework to help with SPA in scenarios a controller must take a certain action on passed parameters but redirect to homepage