### PR TITLE
Patch 1

### DIFF
--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -66,7 +66,8 @@ std::string getUuid();
 
 /// Encode the string to base64 format.
 std::string base64Encode(const unsigned char *bytes_to_encode,
-                         unsigned int in_len);
+                         unsigned int in_len,
+                         bool url_safe=false);
 
 /// Decode the base64 format string.
 std::string base64Decode(const std::string &encoded_string);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -67,7 +67,7 @@ std::string getUuid();
 /// Encode the string to base64 format.
 std::string base64Encode(const unsigned char *bytes_to_encode,
                          unsigned int in_len,
-                         bool url_safe=false);
+                         bool url_safe = false);
 
 /// Decode the base64 format string.
 std::string base64Decode(const std::string &encoded_string);

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -57,10 +57,20 @@ static const std::string urlBase64Chars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789-_";
-    
+
 static inline bool isBase64(unsigned char c)
 {
-    return (isalnum(c) || (c == '+') || (c == '/'));
+    if (isalnum(c))
+        return true;
+    switch (c)
+    {
+        case '+':
+        case '/':
+        case '-':
+        case '_':
+            return true;
+    }
+    return false;
 }
 
 bool isInteger(const std::string &str)
@@ -319,7 +329,7 @@ std::string getUuid()
 }
 
 std::string base64Encode(const unsigned char *bytes_to_encode,
-                         unsigned int in_len, 
+                         unsigned int in_len,
                          bool url_safe)
 {
     std::string ret;
@@ -328,7 +338,7 @@ std::string base64Encode(const unsigned char *bytes_to_encode,
     unsigned char char_array_4[4];
 
     const std::string &charSet = url_safe ? urlBase64Chars : base64Chars;
-    
+
     while (in_len--)
     {
         char_array_3[i++] = *(bytes_to_encode++);
@@ -365,6 +375,7 @@ std::string base64Encode(const unsigned char *bytes_to_encode,
         while ((i++ < 3))
             ret += '=';
     }
+    return ret;
 }
 
 std::vector<char> base64DecodeToVector(const std::string &encoded_string)
@@ -384,8 +395,14 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string)
         if (i == 4)
         {
             for (i = 0; i < 4; ++i)
+            {
+                if (char_array_4[i] == '-')
+                    char_array_4[i] = '+';
+                else if (char_array_4[i] == '_')
+                    char_array_4[i] = '/';
                 char_array_4[i] =
                     static_cast<char>(base64Chars.find(char_array_4[i]));
+            }
 
             char_array_3[0] =
                 (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
@@ -405,8 +422,14 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string)
             char_array_4[j] = 0;
 
         for (int j = 0; j < 4; ++j)
+        {
+            if (char_array_4[j] == '-')
+                char_array_4[j] = '+';
+            else if (char_array_4[j] == '_')
+                char_array_4[j] = '/';
             char_array_4[j] =
                 static_cast<char>(base64Chars.find(char_array_4[j]));
+        }
 
         char_array_3[0] =
             (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
@@ -437,9 +460,14 @@ std::string base64Decode(const std::string &encoded_string)
         if (i == 4)
         {
             for (i = 0; i < 4; ++i)
+            {
+                if (char_array_4[i] == '-')
+                    char_array_4[i] = '+';
+                else if (char_array_4[i] == '_')
+                    char_array_4[i] = '/';
                 char_array_4[i] = static_cast<unsigned char>(
                     base64Chars.find(char_array_4[i]));
-
+            }
             char_array_3[0] =
                 (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
             char_array_3[1] = ((char_array_4[1] & 0xf) << 4) +
@@ -458,8 +486,14 @@ std::string base64Decode(const std::string &encoded_string)
             char_array_4[j] = 0;
 
         for (int j = 0; j < 4; ++j)
+        {
+            if (char_array_4[j] == '-')
+                char_array_4[j] = '+';
+            else if (char_array_4[j] == '_')
+                char_array_4[j] = '/';
             char_array_4[j] =
                 static_cast<unsigned char>(base64Chars.find(char_array_4[j]));
+        }
 
         char_array_3[0] =
             (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -43,6 +43,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdarg.h>
+#include <map>
 
 namespace drogon
 {

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -314,7 +314,8 @@ std::string getUuid()
 }
 
 std::string base64Encode(const unsigned char *bytes_to_encode,
-                         unsigned int in_len, bool url_safe)
+                         unsigned int in_len, 
+                         bool url_safe)
 {
     std::string ret;
     int i = 0;

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -314,7 +314,7 @@ std::string getUuid()
 }
 
 std::string base64Encode(const unsigned char *bytes_to_encode,
-                         unsigned int in_len)
+                         unsigned int in_len, bool url_safe)
 {
     std::string ret;
     int i = 0;
@@ -357,7 +357,17 @@ std::string base64Encode(const unsigned char *bytes_to_encode,
         while ((i++ < 3))
             ret += '=';
     }
-
+    if ( url_safe )
+    {
+        char r;
+        std::map<char, char> rs = {{'+', '-'}, {'/', '_'}};
+        std::replace_if(ret.begin(), ret.end(), 
+            [&](const char &c)
+            {
+                return (rs.find(c) != rs.end()) && (r = rs[c]);
+            },
+        r); 
+    }
     return ret;
 }
 

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -43,7 +43,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdarg.h>
-#include <map>
 
 namespace drogon
 {
@@ -54,6 +53,11 @@ static const std::string base64Chars =
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789+/";
 
+static const std::string urlBase64Chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789-_";
+    
 static inline bool isBase64(unsigned char c)
 {
     return (isalnum(c) || (c == '+') || (c == '/'));
@@ -323,6 +327,8 @@ std::string base64Encode(const unsigned char *bytes_to_encode,
     unsigned char char_array_3[3];
     unsigned char char_array_4[4];
 
+    const std::string &charSet = url_safe ? urlBase64Chars : base64Chars;
+    
     while (in_len--)
     {
         char_array_3[i++] = *(bytes_to_encode++);
@@ -336,7 +342,7 @@ std::string base64Encode(const unsigned char *bytes_to_encode,
             char_array_4[3] = char_array_3[2] & 0x3f;
 
             for (i = 0; (i < 4); ++i)
-                ret += base64Chars[char_array_4[i]];
+                ret += charSet[char_array_4[i]];
             i = 0;
         }
     }
@@ -354,23 +360,11 @@ std::string base64Encode(const unsigned char *bytes_to_encode,
         char_array_4[3] = char_array_3[2] & 0x3f;
 
         for (int j = 0; (j < i + 1); ++j)
-            ret += base64Chars[char_array_4[j]];
+            ret += charSet[char_array_4[j]];
 
         while ((i++ < 3))
             ret += '=';
     }
-    if ( url_safe )
-    {
-        char r;
-        std::map<char, char> rs = {{'+', '-'}, {'/', '_'}};
-        std::replace_if(ret.begin(), ret.end(), 
-            [&](const char &c)
-            {
-                return (rs.find(c) != rs.end()) && (r = rs[c]);
-            },
-        r); 
-    }
-    return ret;
 }
 
 std::vector<char> base64DecodeToVector(const std::string &encoded_string)

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -57,6 +57,37 @@ static const std::string urlBase64Chars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789-_";
+class Base64CharMap
+{
+  public:
+    Base64CharMap()
+    {
+        char index = 0;
+        for (char c = 'A'; c <= 'Z'; ++c)
+        {
+            charMap_[c] = index++;
+        }
+        for (char c = 'a'; c <= 'z'; ++c)
+        {
+            charMap_[c] = index++;
+        }
+        for (char c = '0'; c <= '9'; ++c)
+        {
+            charMap_[c] = index++;
+        }
+        charMap_['+'] = charMap_['-'] = index++;
+        charMap_['/'] = charMap_['_'] = index;
+        charMap_[0] = 0xff;
+    }
+    char getIndex(const char c) const noexcept
+    {
+        return charMap_[c];
+    }
+
+  private:
+    char charMap_[256]{0};
+};
+const static Base64CharMap base64CharMap;
 
 static inline bool isBase64(unsigned char c)
 {
@@ -396,12 +427,7 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string)
         {
             for (i = 0; i < 4; ++i)
             {
-                if (char_array_4[i] == '-')
-                    char_array_4[i] = '+';
-                else if (char_array_4[i] == '_')
-                    char_array_4[i] = '/';
-                char_array_4[i] =
-                    static_cast<char>(base64Chars.find(char_array_4[i]));
+                char_array_4[i] = base64CharMap.getIndex(char_array_4[i]);
             }
 
             char_array_3[0] =
@@ -423,12 +449,7 @@ std::vector<char> base64DecodeToVector(const std::string &encoded_string)
 
         for (int j = 0; j < 4; ++j)
         {
-            if (char_array_4[j] == '-')
-                char_array_4[j] = '+';
-            else if (char_array_4[j] == '_')
-                char_array_4[j] = '/';
-            char_array_4[j] =
-                static_cast<char>(base64Chars.find(char_array_4[j]));
+            char_array_4[j] = base64CharMap.getIndex(char_array_4[j]);
         }
 
         char_array_3[0] =
@@ -461,12 +482,7 @@ std::string base64Decode(const std::string &encoded_string)
         {
             for (i = 0; i < 4; ++i)
             {
-                if (char_array_4[i] == '-')
-                    char_array_4[i] = '+';
-                else if (char_array_4[i] == '_')
-                    char_array_4[i] = '/';
-                char_array_4[i] = static_cast<unsigned char>(
-                    base64Chars.find(char_array_4[i]));
+                char_array_4[i] = base64CharMap.getIndex(char_array_4[i]);
             }
             char_array_3[0] =
                 (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
@@ -487,12 +503,7 @@ std::string base64Decode(const std::string &encoded_string)
 
         for (int j = 0; j < 4; ++j)
         {
-            if (char_array_4[j] == '-')
-                char_array_4[j] = '+';
-            else if (char_array_4[j] == '_')
-                char_array_4[j] = '/';
-            char_array_4[j] =
-                static_cast<unsigned char>(base64Chars.find(char_array_4[j]));
+            char_array_4[j] = base64CharMap.getIndex(char_array_4[j]);
         }
 
         char_array_3[0] =

--- a/unittest/Base64Unittest.cpp
+++ b/unittest/Base64Unittest.cpp
@@ -1,0 +1,57 @@
+#include <drogon/utils/Utilities.h>
+#include <gtest/gtest.h>
+#include <string>
+
+TEST(Base64, base64)
+{
+    std::string in{"drogon framework"};
+    auto out = drogon::utils::base64Encode((const unsigned char *)in.data(),
+                                           in.length());
+    auto out2 = drogon::utils::base64Decode(out);
+    EXPECT_EQ(out, "ZHJvZ29uIGZyYW1ld29yaw==");
+    EXPECT_EQ(out2, in);
+}
+
+TEST(Base64, base64_long_string)
+{
+    std::string in;
+    for (int i = 0; i < 100000; ++i)
+    {
+        in.append(1, char(i));
+    }
+    auto out = drogon::utils::base64Encode((const unsigned char *)in.data(),
+                                           in.length());
+    auto out2 = drogon::utils::base64Decode(out);
+    EXPECT_EQ(out2, in);
+}
+
+TEST(Base64, base64_url)
+{
+    std::string in{"drogon framework"};
+    auto out = drogon::utils::base64Encode((const unsigned char *)in.data(),
+                                           in.length(),
+                                           true);
+    auto out2 = drogon::utils::base64Decode(out);
+    EXPECT_EQ(out, "ZHJvZ29uIGZyYW1ld29yaw==");
+    EXPECT_EQ(out2, in);
+}
+
+TEST(Base64, base64_long_string_url)
+{
+    std::string in;
+    for (int i = 0; i < 100000; ++i)
+    {
+        in.append(1, char(i));
+    }
+    auto out = drogon::utils::base64Encode((const unsigned char *)in.data(),
+                                           in.length(),
+                                           true);
+    auto out2 = drogon::utils::base64Decode(out);
+    EXPECT_EQ(out2, in);
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(gzip_unittest GzipUnittest.cpp)
 add_executable(md5_unittest MD5Unittest.cpp ../lib/src/ssl_funcs/Md5.cc)
 add_executable(sha1_unittest SHA1Unittest.cpp ../lib/src/ssl_funcs/Sha1.cc)
 add_executable(ostringstream_unittest OStringStreamUnitttest.cpp)
+add_executable(base64_unittest Base64Unittest.cpp)
 if(Brotli_FOUND)
   add_executable(brotli_unittest BrotliUnittest.cpp)
 endif()
@@ -14,7 +15,8 @@ set(UNITTEST_TARGETS
     gzip_unittest
     md5_unittest
     sha1_unittest
-    ostringstream_unittest)
+    ostringstream_unittest
+    base64_unittest)
 if(Brotli_FOUND)
   set(UNITTEST_TARGETS ${UNITTEST_TARGETS} brotli_unittest)
 endif()


### PR DESCRIPTION
Provide option for url-safe base64encode.
The url will be broken in requestparser if its generated from generated from base64encode (sometimes contain '+').