### PR TITLE
Pass Data From View to Its Layout Container

### DIFF
--- a/drogon_ctl/create_view.cc
+++ b/drogon_ctl/create_view.cc
@@ -456,7 +456,7 @@ void create_view::newViewSourceFile(std::ofstream &file,
     file << "return ret;\n}else\n{\n";
     file << "auto templ = DrTemplateBase::newTemplate(layoutName);\n";
     file << "if(!templ) return \"\";\n";
-    file << "HttpViewData data;\n";
+    file << "HttpViewData data = " << viewDataName << ";\n";
     file << "auto str = std::move(" << streamName << ".str());\n";
     file << "if(!str.empty() && str[str.length()-1] == '\\n') "
             "str.resize(str.length()-1);\n";


### PR DESCRIPTION
This fixes #428.

During tests on macOS with dynamic layouts turned on (“development mode”), I discovered that this change sometimes introduces segmentation faults which I haven’t analyzed yet, but it works when properly compiled for production.