### PR TITLE
Fix building of ORM on FreeBSD

### DIFF
--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -31,10 +31,20 @@
 #include <vector>
 #ifdef _WIN32
 #include <winsock2.h>
+#else // some Unix-like OS
+#include <arpa/inet.h>
 #endif
+
+#if defined __linux__ || defined __FreeBSD__
 
 #ifdef __linux__
 #include <endian.h>   // __BYTE_ORDER __LITTLE_ENDIAN
+#elif defined __FreeBSD__
+#include <sys/endian.h> // _BYTE_ORDER _LITTLE_ENDIAN
+#define __BYTE_ORDER _BYTE_ORDER
+#define __LITTLE_ENDIAN _LITTLE_ENDIAN
+#endif
+
 #include <algorithm>  // std::reverse()
 
 template <typename T>

--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -31,16 +31,16 @@
 #include <vector>
 #ifdef _WIN32
 #include <winsock2.h>
-#else // some Unix-like OS
+#else  // some Unix-like OS
 #include <arpa/inet.h>
 #endif
 
 #if defined __linux__ || defined __FreeBSD__
 
 #ifdef __linux__
-#include <endian.h>   // __BYTE_ORDER __LITTLE_ENDIAN
+#include <endian.h>  // __BYTE_ORDER __LITTLE_ENDIAN
 #elif defined __FreeBSD__
-#include <sys/endian.h> // _BYTE_ORDER _LITTLE_ENDIAN
+#include <sys/endian.h>  // _BYTE_ORDER _LITTLE_ENDIAN
 #define __BYTE_ORDER _BYTE_ORDER
 #define __LITTLE_ENDIAN _LITTLE_ENDIAN
 #endif


### PR DESCRIPTION
Figured out Drogon doesn't build when I tried to build the tests and narrowed it down to `SqlBinder.h`. In Linux, something other header is including `arpa/inet.h` so it's not necessary to explicitly have it, but it doesn't hurt either. In FreeBSD it's absolutely necessary.

This approach with #defines might not be the cleanest way to do byte order checking, but it works.