### PR TITLE
Added additional formats for getHttpDate function and fixed undefined behavior upon error (#453)

### DIFF
--- a/lib/inc/drogon/Cookie.h
+++ b/lib/inc/drogon/Cookie.h
@@ -13,8 +13,9 @@
  */
 #pragma once
 
-#include <string>
 #include <trantor/utils/Date.h>
+#include <string>
+#include <limits>
 
 namespace drogon
 {

--- a/lib/inc/drogon/Cookie.h
+++ b/lib/inc/drogon/Cookie.h
@@ -235,7 +235,7 @@ class Cookie
     }
 
   private:
-    trantor::Date expiresDate_;
+    trantor::Date expiresDate_{std::numeric_limits<int64_t>::max()};
     bool httpOnly_{true};
     bool secure_{false};
     std::string domain_;

--- a/lib/inc/drogon/Cookie.h
+++ b/lib/inc/drogon/Cookie.h
@@ -236,8 +236,7 @@ class Cookie
     }
 
   private:
-    trantor::Date expiresDate_{
-        trantor::Date(std::numeric_limits<int64_t>::max())};
+    trantor::Date expiresDate_{(std::numeric_limits<int64_t>::max)()};
     bool httpOnly_{true};
     bool secure_{false};
     std::string domain_;

--- a/lib/inc/drogon/Cookie.h
+++ b/lib/inc/drogon/Cookie.h
@@ -236,7 +236,8 @@ class Cookie
     }
 
   private:
-    trantor::Date expiresDate_{std::numeric_limits<int64_t>::max()};
+    trantor::Date expiresDate_{
+        trantor::Date(std::numeric_limits<int64_t>::max())};
     bool httpOnly_{true};
     bool secure_{false};
     std::string domain_;

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -125,6 +125,9 @@ std::string brotliDecompress(const char *data, const size_t ndata);
 char *getHttpFullDate(const trantor::Date &date = trantor::Date::now());
 
 /// Get the trantor::Date object according to the http full date string
+/**
+ * Returns trantor::Date(-1) upon failure.
+ */
 trantor::Date getHttpDate(const std::string &httpFullDateString);
 
 /// Get a formatted string

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <limits>
 #ifdef _WIN32
 #include <time.h>
 char *strptime(const char *s, const char *f, struct tm *tm);
@@ -126,7 +127,7 @@ char *getHttpFullDate(const trantor::Date &date = trantor::Date::now());
 
 /// Get the trantor::Date object according to the http full date string
 /**
- * Returns trantor::Date(-1) upon failure.
+ * Returns trantor::Date(std::numeric_limits<int64_t>::max()) upon failure.
  */
 trantor::Date getHttpDate(const std::string &httpFullDateString);
 

--- a/lib/src/Cookie.cc
+++ b/lib/src/Cookie.cc
@@ -19,7 +19,9 @@ std::string Cookie::cookieString() const
 {
     std::string ret = "Set-Cookie: ";
     ret.append(key_).append("= ").append(value_).append("; ");
-    if (expiresDate_.microSecondsSinceEpoch() > 0)
+    if (expiresDate_.microSecondsSinceEpoch() !=
+            std::numeric_limits<int64_t>::max() &&
+        expiresDate_.microSecondsSinceEpoch() >= 0)
     {
         ret.append("Expires= ")
             .append(utils::getHttpFullDate(expiresDate_))

--- a/lib/src/Cookie.cc
+++ b/lib/src/Cookie.cc
@@ -20,7 +20,7 @@ std::string Cookie::cookieString() const
     std::string ret = "Set-Cookie: ";
     ret.append(key_).append("= ").append(value_).append("; ");
     if (expiresDate_.microSecondsSinceEpoch() !=
-            std::numeric_limits<int64_t>::max() &&
+            (std::numeric_limits<int64_t>::max)() &&
         expiresDate_.microSecondsSinceEpoch() >= 0)
     {
         ret.append("Expires= ")

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -935,7 +935,7 @@ char *getHttpFullDate(const trantor::Date &date)
 }
 trantor::Date getHttpDate(const std::string &httpFullDateString)
 {
-    const std::array<const char *, 4> formats = {
+    static const std::array<const char *, 4> formats = {
         // RFC822 (default)
         "%a, %d %b %Y %H:%M:%S",
         // RFC 850 (deprecated)
@@ -951,18 +951,12 @@ trantor::Date getHttpDate(const std::string &httpFullDateString)
     {
         if (strptime(httpFullDateString.c_str(), format, &tmptm) != NULL)
         {
-            found = true;
-            break;
+            auto epoch = timegm(&tmptm);
+            return trantor::Date(epoch * MICRO_SECONDS_PRE_SEC);
         }
     }
-    if (!found)
-    {
-        LOG_WARN << "invalid datetime format: '" << httpFullDateString << "'";
-        return trantor::Date(-1);
-    }
-
-    auto epoch = timegm(&tmptm);
-    return trantor::Date(epoch * MICRO_SECONDS_PRE_SEC);
+    LOG_WARN << "invalid datetime format: '" << httpFullDateString << "'";
+    return trantor::Date(std::numeric_limits<int64_t>::max());
 }
 std::string formattedString(const char *format, ...)
 {

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -33,6 +33,7 @@
 #include <string>
 #include <thread>
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cstdlib>
 #include <stdio.h>

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -946,7 +946,6 @@ trantor::Date getHttpDate(const std::string &httpFullDateString)
         "%a, %d-%b-%Y %H:%M:%S",
     };
     struct tm tmptm;
-    bool found = false;
     for (const char *format : formats)
     {
         if (strptime(httpFullDateString.c_str(), format, &tmptm) != NULL)

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -956,7 +956,7 @@ trantor::Date getHttpDate(const std::string &httpFullDateString)
         }
     }
     LOG_WARN << "invalid datetime format: '" << httpFullDateString << "'";
-    return trantor::Date(std::numeric_limits<int64_t>::max());
+    return trantor::Date((std::numeric_limits<int64_t>::max)());
 }
 std::string formattedString(const char *format, ...)
 {

--- a/lib/tests/HttpFullDateTest.cc
+++ b/lib/tests/HttpFullDateTest.cc
@@ -8,31 +8,4 @@ int main()
     std::cout << str << std::endl;
     auto date = utils::getHttpDate(str);
     std::cout << utils::getHttpFullDate(date) << std::endl;
-
-    {
-        // rfc 850
-        auto date = utils::getHttpDate("Fri, 05-Jun-20 09:19:38 GMT");
-        std::cout << (date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC)
-                  << " should be " << 1591348778 << std::endl;
-    }
-    {
-        // reddit format
-        auto date = utils::getHttpDate("Fri, 05-Jun-2020 09:19:38 GMT");
-        std::cout << (date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC)
-                  << " should be " << 1591348778 << std::endl;
-    }
-    {
-        // asctime format
-        auto epoch = time(nullptr);
-        auto str = asctime(localtime(&epoch));
-        auto date = utils::getHttpDate(str);
-        std::cout << (date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC)
-                  << " should be " << epoch << std::endl;
-    }
-    {
-        // invalid format
-        auto date = utils::getHttpDate("Fri, this format is invalid");
-        std::cout << date.microSecondsSinceEpoch() << " should be " << -1
-                  << std::endl;
-    }
 }

--- a/lib/tests/HttpFullDateTest.cc
+++ b/lib/tests/HttpFullDateTest.cc
@@ -8,4 +8,31 @@ int main()
     std::cout << str << std::endl;
     auto date = utils::getHttpDate(str);
     std::cout << utils::getHttpFullDate(date) << std::endl;
+
+    {
+        // rfc 850
+        auto date = utils::getHttpDate("Fri, 05-Jun-20 09:19:38 GMT");
+        std::cout << (date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC)
+                  << " should be " << 1591348778 << std::endl;
+    }
+    {
+        // reddit format
+        auto date = utils::getHttpDate("Fri, 05-Jun-2020 09:19:38 GMT");
+        std::cout << (date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC)
+                  << " should be " << 1591348778 << std::endl;
+    }
+    {
+        // asctime format
+        auto epoch = time(nullptr);
+        auto str = asctime(localtime(&epoch));
+        auto date = utils::getHttpDate(str);
+        std::cout << (date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC)
+                  << " should be " << epoch << std::endl;
+    }
+    {
+        // invalid format
+        auto date = utils::getHttpDate("Fri, this format is invalid");
+        std::cout << date.microSecondsSinceEpoch() << " should be " << -1
+                  << std::endl;
+    }
 }

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(sha1_unittest SHA1Unittest.cpp ../lib/src/ssl_funcs/Sha1.cc)
 add_executable(ostringstream_unittest OStringStreamUnitttest.cpp)
 add_executable(base64_unittest Base64Unittest.cpp)
 add_executable(pubsubservice_unittest PubSubServiceUnittest.cpp)
+add_executable(httpdate_unittest HttpDateUnittest.cpp)
 if(Brotli_FOUND)
   add_executable(brotli_unittest BrotliUnittest.cpp)
 endif()
@@ -18,7 +19,8 @@ set(UNITTEST_TARGETS
     sha1_unittest
     ostringstream_unittest
     base64_unittest
-    pubsubservice_unittest)
+    pubsubservice_unittest
+    httpdate_unittest)
 if(Brotli_FOUND)
   set(UNITTEST_TARGETS ${UNITTEST_TARGETS} brotli_unittest)
 endif()

--- a/unittest/HttpDateUnittest.cpp
+++ b/unittest/HttpDateUnittest.cpp
@@ -1,0 +1,35 @@
+#include <drogon/utils/Utilities.h>
+#include <gtest/gtest.h>
+using namespace drogon;
+
+TEST(HttpDate, rfc850)
+{
+    auto date = utils::getHttpDate("Fri, 05-Jun-20 09:19:38 GMT");
+    EXPECT_EQ(date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC, 1591348778);
+}
+
+TEST(HttpDate, redditFormat)
+{
+    auto date = utils::getHttpDate("Fri, 05-Jun-2020 09:19:38 GMT");
+    EXPECT_EQ(date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC, 1591348778);
+}
+
+TEST(HttpDate, invalidFormat)
+{
+    auto date = utils::getHttpDate("Fri, this format is invalid");
+    EXPECT_EQ(date.microSecondsSinceEpoch(), std::numeric_limits<int64_t>::max());
+}
+
+TEST(HttpDate, asctimeFormat)
+{
+    auto epoch = time(nullptr);
+    auto str = asctime(gmtime(&epoch));
+    auto date = utils::getHttpDate(str);
+    EXPECT_EQ(date.microSecondsSinceEpoch() / MICRO_SECONDS_PRE_SEC, epoch);
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/unittest/HttpDateUnittest.cpp
+++ b/unittest/HttpDateUnittest.cpp
@@ -17,7 +17,7 @@ TEST(HttpDate, redditFormat)
 TEST(HttpDate, invalidFormat)
 {
     auto date = utils::getHttpDate("Fri, this format is invalid");
-    EXPECT_EQ(date.microSecondsSinceEpoch(), std::numeric_limits<int64_t>::max());
+    EXPECT_EQ(date.microSecondsSinceEpoch(), (std::numeric_limits<int64_t>::max)());
 }
 
 TEST(HttpDate, asctimeFormat)


### PR DESCRIPTION
This patch fixes a bug where drogon would use uninitialized values if the string passed to utils::getHttpDate isn't formatted correctly. In addition to that, it also adds support for RFC 850 and asctime formats. 