### PR TITLE
Fix a bug in ListenerManager::getIOLoop()

### DIFF
--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -207,13 +207,13 @@ trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
     if ( 0 == n )
     {
       	LOG_WARN << "Please call getIOLoop() after drogon::app().run()";
-		    return nullptr;
+        return nullptr;
     }
 #ifdef __linux__
     if (id >= n)
     {
         LOG_TRACE << "Loop id (" << id << ") out of range [0-"
-                  << listeningloopThreads_.size() << ").";
+                  << n << ").";
         id %= n;
         LOG_TRACE << "Rounded to : " << id;
     }
@@ -223,7 +223,7 @@ trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
     if (id >= n)
     {
         LOG_TRACE << "Loop id (" << id << ") out of range [0-"
-                  << listeningloopThreads_.size() << ").";
+                  << n << ").";
         id %= n;
         LOG_TRACE << "Rounded to : " << id;
     }

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -210,21 +210,21 @@ trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
 		    return nullptr;
     }
 #ifdef __linux__
-    if (id >= listeningloopThreads_.size())
+    if (id >= n)
     {
         LOG_TRACE << "Loop id (" << id << ") out of range [0-"
                   << listeningloopThreads_.size() << ").";
-        id %= listeningloopThreads_.size();
+        id %= n;
         LOG_TRACE << "Rounded to : " << id;
     }
     assert(listeningloopThreads_[id]);
     return listeningloopThreads_[id]->getLoop();
 #else
-    if (id >= ioLoopThreadPoolPtr_->size())
+    if (id >= n)
     {
         LOG_TRACE << "Loop id (" << id << ") out of range [0-"
                   << listeningloopThreads_.size() << ").";
-        id %= ioLoopThreadPoolPtr_->size();
+        id %= n;
         LOG_TRACE << "Rounded to : " << id;
     }
     return ioLoopThreadPoolPtr_->getLoop(id);

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -203,6 +203,12 @@ ListenerManager::~ListenerManager()
 
 trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
 {
+    const size_t &&n = listeningloopThreads_.size();
+    if ( 0 == n )
+    {
+      	LOG_WARN << "Please call getIOLoop() after drogon::app().run()";
+		    return nullptr;
+    }
 #ifdef __linux__
     if (id >= listeningloopThreads_.size())
     {

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -209,22 +209,16 @@ trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
         LOG_WARN << "Please call getIOLoop() after drogon::app().run()";
         return nullptr;
     }
-#ifdef __linux__
     if (id >= n)
     {
         LOG_TRACE << "Loop id (" << id << ") out of range [0-" << n << ").";
         id %= n;
         LOG_TRACE << "Rounded to : " << id;
     }
+#ifdef __linux__
     assert(listeningloopThreads_[id]);
     return listeningloopThreads_[id]->getLoop();
 #else
-    if (id >= n)
-    {
-        LOG_TRACE << "Loop id (" << id << ") out of range [0-" << n << ").";
-        id %= n;
-        LOG_TRACE << "Rounded to : " << id;
-    }
     return ioLoopThreadPoolPtr_->getLoop(id);
 #endif
 }

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -203,17 +203,16 @@ ListenerManager::~ListenerManager()
 
 trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
 {
-    const size_t &&n = listeningloopThreads_.size();
+    auto const n = listeningloopThreads_.size();
     if (0 == n)
     {
-      	LOG_WARN << "Please call getIOLoop() after drogon::app().run()";
+        LOG_WARN << "Please call getIOLoop() after drogon::app().run()";
         return nullptr;
     }
 #ifdef __linux__
     if (id >= n)
     {
-        LOG_TRACE << "Loop id (" << id << ") out of range [0-"
-                  << n << ").";
+        LOG_TRACE << "Loop id (" << id << ") out of range [0-" << n << ").";
         id %= n;
         LOG_TRACE << "Rounded to : " << id;
     }
@@ -222,8 +221,7 @@ trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
 #else
     if (id >= n)
     {
-        LOG_TRACE << "Loop id (" << id << ") out of range [0-"
-                  << n << ").";
+        LOG_TRACE << "Loop id (" << id << ") out of range [0-" << n << ").";
         id %= n;
         LOG_TRACE << "Rounded to : " << id;
     }

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -204,7 +204,7 @@ ListenerManager::~ListenerManager()
 trantor::EventLoop *ListenerManager::getIOLoop(size_t id) const
 {
     const size_t &&n = listeningloopThreads_.size();
-    if ( 0 == n )
+    if (0 == n)
     {
       	LOG_WARN << "Please call getIOLoop() after drogon::app().run()";
         return nullptr;


### PR DESCRIPTION
Issue warning when called before app().run()/no IO-thread exist.