### PR TITLE
SessionManager: Allow backend storage to be configurable

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -142,6 +142,28 @@ class HttpAppFramework : public trantor::NonCopyable
     virtual const std::function<HttpResponsePtr(HttpStatusCode)>
         &getCustomErrorHandler() const = 0;
 
+    /// Set custom session storage creator
+    /**
+     * @param resp_generator is invoked when the system starts running and is
+     * used to provide backing data storage for the built-in session handler.
+     * The two parameters are the event loop of the system and the timeout for
+     * keys.
+     */
+    virtual HttpAppFramework &setCustomSessionStorageCreator(
+        std::function<
+            std::unique_ptr<SessionStorageProvider>(trantor::EventLoop *,
+                                                    size_t)> &&creator) = 0;
+
+    /// Get custom session storage creator
+    /**
+     * @return A const-reference to the session storage creator set using
+     * setCustomSessionStorageCreator. If none was provided, the default creator
+     * is returned.
+     */
+    virtual const std::function<
+        std::unique_ptr<SessionStorageProvider>(trantor::EventLoop *, size_t)>
+        &getCustomSessionStorageCreator() const = 0;
+
     /// Get the plugin object registered in the framework
     /**
      * @note

--- a/lib/inc/drogon/Session.h
+++ b/lib/inc/drogon/Session.h
@@ -166,4 +166,30 @@ class Session
 
 using SessionPtr = std::shared_ptr<Session>;
 
+class SessionStorageProvider
+{
+  public:
+    virtual ~SessionStorageProvider();
+
+    /// Atomically find and get the value of a keyword
+    /**
+     * Return true when the value is found, and the value
+     * is assigned to the value argument.
+     */
+    virtual bool findAndFetch(const std::string &key, SessionPtr &value) = 0;
+
+    /**
+     * @brief Insert a key-value pair into the storage provider.
+     *
+     * @param key The key
+     * @param value The value
+     * @param timeout The timeout in seconds, if timeout > 0, the value will be
+     * erased within the 'timeout' seconds after the last access. If the timeout
+     * is zero, the value exists until being removed explicitly.
+     */
+    virtual void insert(const std::string &key,
+                        SessionPtr &&value,
+                        size_t timeout) = 0;
+};
+
 }  // namespace drogon

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -498,8 +498,9 @@ void HttpAppFrameworkImpl::run()
 
     if (useSession_)
     {
-        sessionManagerPtr_ = std::unique_ptr<SessionManager>(
-            new SessionManager(getLoop(), sessionTimeout_));
+        sessionManagerPtr_ = std::make_unique<SessionManager>(
+            sessionStorageCreator_(getLoop(), sessionTimeout_),
+            sessionTimeout_);
     }
 
     // Initialize plugins
@@ -981,4 +982,19 @@ const std::function<HttpResponsePtr(HttpStatusCode)>
     &HttpAppFrameworkImpl::getCustomErrorHandler() const
 {
     return customErrorHandler_;
+}
+
+HttpAppFramework &HttpAppFrameworkImpl::setCustomSessionStorageCreator(
+    std::function<std::unique_ptr<SessionStorageProvider>(trantor::EventLoop *,
+                                                          size_t)> &&creator)
+{
+    sessionStorageCreator_ = std::move(creator);
+    return *this;
+}
+
+const std::function<
+    std::unique_ptr<SessionStorageProvider>(trantor::EventLoop *, size_t)>
+    &HttpAppFrameworkImpl::getCustomSessionStorageCreator() const
+{
+    return sessionStorageCreator_;
 }

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "impl_forwards.h"
+#include "SessionManager.h"
 #include <drogon/HttpAppFramework.h>
 #include <drogon/config.h>
 #include <memory>
@@ -197,6 +198,15 @@ class HttpAppFrameworkImpl : public HttpAppFramework
         useSession_ = false;
         return *this;
     }
+
+    HttpAppFramework &setCustomSessionStorageCreator(
+        std::function<std::unique_ptr<SessionStorageProvider>(
+            trantor::EventLoop *,
+            size_t)> &&creator) override;
+    const std::function<
+        std::unique_ptr<SessionStorageProvider>(trantor::EventLoop *, size_t)>
+        &getCustomSessionStorageCreator() const override;
+
     virtual const std::string &getDocumentRoot() const override
     {
         return rootPath_;
@@ -547,6 +557,7 @@ class HttpAppFrameworkImpl : public HttpAppFramework
     size_t clientMaxWebSocketMessageSize_{128 * 1024};
     std::string homePageFile_{"index.html"};
     std::function<void()> termSignalHandler_{[]() { app().quit(); }};
+    std::function<std::unique_ptr<SessionStorageProvider>(trantor::EventLoop*, size_t)> sessionStorageCreator_{createCacheMapProvider};
     std::unique_ptr<SessionManager> sessionManagerPtr_;
     Json::Value jsonConfig_;
     HttpResponsePtr custom404_;

--- a/lib/src/SessionManager.h
+++ b/lib/src/SessionManager.h
@@ -24,20 +24,24 @@
 
 namespace drogon
 {
+std::unique_ptr<SessionStorageProvider> createCacheMapProvider(
+    trantor::EventLoop *loop,
+    size_t timeout);
+
 class SessionManager : public trantor::NonCopyable
 {
   public:
-    SessionManager(trantor::EventLoop *loop, size_t timeout);
+    SessionManager(std::unique_ptr<SessionStorageProvider> provider,
+                   size_t timeout);
     ~SessionManager()
     {
-        sessionMapPtr_.reset();
+        provider_.reset();
     }
     SessionPtr getSession(const std::string &sessionID, bool needToSet);
 
   private:
-    std::unique_ptr<CacheMap<std::string, SessionPtr>> sessionMapPtr_;
+    std::unique_ptr<SessionStorageProvider> provider_;
     std::mutex mapMutex_;
-    trantor::EventLoop *loop_;
     size_t timeout_;
 };
 }  // namespace drogon


### PR DESCRIPTION
This allows using the built-in session feature without having to use the CacheMap, which is limited to the current process and not suitable in larger deployments.

In my use case of drogon, I am running multiple pods behind a single load-balancer, so the built-in session handler won't work without sticky load balancing, which isn't feasible and is more of a bandaid fix. This allows the user to optionally specify their own implementation of backing storage, for example using redis. By default, CacheMap is used and current usages should require no changes, it is opt-in only.