### PR TITLE
Modify static files router and 404 pages generator

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -980,6 +980,7 @@ HttpAppFramework &HttpAppFrameworkImpl::setCustomErrorHandler(
     std::function<HttpResponsePtr(HttpStatusCode)> &&resp_generator)
 {
     customErrorHandler_ = std::move(resp_generator);
+    usingCustomErrorHandler_ = true;
     return *this;
 }
 

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -481,6 +481,10 @@ class HttpAppFrameworkImpl : public HttpAppFramework
     virtual bool areAllDbClientsAvailable() const noexcept override;
     const std::function<HttpResponsePtr(HttpStatusCode)>
         &getCustomErrorHandler() const override;
+    bool isUsingCustomErrorHandler() const
+    {
+        return usingCustomErrorHandler_;
+    }
 
   private:
     virtual void registerHttpController(
@@ -558,6 +562,7 @@ class HttpAppFrameworkImpl : public HttpAppFramework
     bool useGzip_{true};
     bool useBrotli_{false};
     bool usingUnicodeEscaping_{true};
+    bool usingCustomErrorHandler_{false};
     size_t clientMaxBodySize_{1024 * 1024};
     size_t clientMaxMemoryBodySize_{64 * 1024};
     size_t clientMaxWebSocketMessageSize_{128 * 1024};

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -64,6 +64,11 @@ void StaticFileRouter::route(
         callback(app().getCustomErrorHandler()(k403Forbidden));
         return;
     }
+    if (req->method() != Get)
+    {
+        callback(app().getCustomErrorHandler()(k405MethodNotAllowed));
+        return;
+    }
     auto lPath = path;
     std::transform(lPath.begin(), lPath.end(), lPath.begin(), tolower);
 


### PR DESCRIPTION
1. Except for the GET method, it is forbidden to use any other method for accessing static files.

2. Use following sequence to create 404 pages.
 * try to use user customized 404 handler;
 * try to use user customized error handler;
 * use default handler to create 404 pages;