### PR TITLE
 Fix zlib link error on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,11 +194,6 @@ if(BUILD_ORM)
     set(DROGON_SOURCES ${DROGON_SOURCES}
                        orm_lib/src/mysql_impl/MysqlConnection.cc
                        orm_lib/src/mysql_impl/MysqlResultImpl.cc)
-  else(MySQL_FOUND)
-    if(MSVC)
-      find_package(ZLIB REQUIRED)
-      target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
-    endif(MSVC)
   endif(MySQL_FOUND)
 
   # Find sqlite3.
@@ -211,10 +206,8 @@ if(BUILD_ORM)
   endif(SQLite3_FOUND)
 endif(BUILD_ORM)
 
-if((NOT MSVC) OR (NOT BUILD_ORM))
-  find_package(ZLIB REQUIRED)
-  target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
-endif((NOT MSVC) OR (NOT BUILD_ORM))
+find_package(ZLIB REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
 
 find_package(OpenSSL)
 if(OpenSSL_FOUND)


### PR DESCRIPTION
After the PR https://github.com/microsoft/vcpkg/commit/a5d23385e57bbb35a22dadcf40fc1801fb968aed, the zlib library is separated from libmariadb, so we should link against it explicitly.