### PR TITLE
Add support for status code 418

### DIFF
--- a/lib/inc/drogon/HttpTypes.h
+++ b/lib/inc/drogon/HttpTypes.h
@@ -56,6 +56,7 @@ enum HttpStatusCode
     k415UnsupportedMediaType = 415,
     k416RequestedRangeNotSatisfiable = 416,
     k417ExpectationFailed = 417,
+    k418ImATeapot = 418,
     k421MisdirectedRequest = 421,
     k425TooEarly = 425,
     k426UpgradeRequired = 426,

--- a/lib/src/HttpUtils.cc
+++ b/lib/src/HttpUtils.cc
@@ -336,6 +336,11 @@ const string_view &statusCodeToString(int code)
             static string_view sv = "Expectation Failed";
             return sv;
         }
+        case 418:
+        {
+            static string_view sv = "I'm a Teapot";
+            return sv;
+        }
         case 421:
         {
             static string_view sv = "Misdirected Request";


### PR DESCRIPTION
Hi,

I'd like to upstream a small change to support HTTP 418 I'm a teapot. I use this status code to tag special responses that need special handling by other software in the system/app (since no one sane uses it). Don't see reasons to not upstream it and it will be a nice Easter agg. 

Best,
marty1885
