### PR TITLE
Suppress sanitizer warning

### DIFF
--- a/lib/inc/drogon/utils/HttpConstraint.h
+++ b/lib/inc/drogon/utils/HttpConstraint.h
@@ -57,7 +57,7 @@ class HttpConstraint
 
   private:
     ConstraintType type_{ConstraintType::None};
-    HttpMethod method_;
+    HttpMethod method_{HttpMethod::Invalid};
     std::string filterName_;
 };
 }  // namespace internal


### PR DESCRIPTION
Add default initializer for `HttpConstraint::method_` member variable to avoid the following warning given by gcc's undefined behavior sanitizer (`-fsanitize=undefined`):

```
drogon/lib/inc/drogon/utils/HttpConstraint.h:30:7: runtime error: load of value 32767, which is not a valid value for type 'HttpMethod'
```