### PR TITLE
remove execution permission on /tmp/drogon.lock

### DIFF
--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -34,7 +34,7 @@ class DrogonFileLocker : public trantor::NonCopyable
   public:
     DrogonFileLocker()
     {
-        fd_ = open("/tmp/drogon.lock", O_TRUNC | O_CREAT, 0755);
+        fd_ = open("/tmp/drogon.lock", O_TRUNC | O_CREAT, 0644);
         flock(fd_, LOCK_EX);
     }
     ~DrogonFileLocker()

--- a/lib/src/ListenerManager.cc
+++ b/lib/src/ListenerManager.cc
@@ -34,7 +34,7 @@ class DrogonFileLocker : public trantor::NonCopyable
   public:
     DrogonFileLocker()
     {
-        fd_ = open("/tmp/drogon.lock", O_TRUNC | O_CREAT, 0644);
+        fd_ = open("/tmp/drogon.lock", O_TRUNC | O_CREAT, 0666);
         flock(fd_, LOCK_EX);
     }
     ~DrogonFileLocker()


### PR DESCRIPTION
Fix #574 

Sets permission to 666 when creating lock. The execution permission seems to be unnecessary. And now it allows all users to lock instead of just the owner.