### PR TITLE
Add ConfigLoader::ConfigLoader(const Json::Value &data)

### DIFF
--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -343,12 +343,17 @@ class HttpAppFramework : public trantor::NonCopyable
     /// Load the configuration from a Json::Value Object.
     /**
      * @param Json::Value Object containing the configuration.
+     * @note Please refer to the configuration file for the content of the json
+     * object.
      */
     virtual HttpAppFramework &loadConfigJson(const Json::Value &data) = 0;
 
     /// Load the configuration from a Json::Value Object.
     /**
-     * @param rvalue reference to a Json::Value object containing the configuration.
+     * @param rvalue reference to a Json::Value object containing the
+     * configuration.
+     * @note Please refer to the configuration file for the content of the json
+     * object.
      */
     virtual HttpAppFramework &loadConfigJson(Json::Value &&data) = 0;
 

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -340,6 +340,18 @@ class HttpAppFramework : public trantor::NonCopyable
      */
     virtual HttpAppFramework &loadConfigFile(const std::string &fileName) = 0;
 
+    /// Load the configuration from a Json::Value Object.
+    /**
+     * @param Json::Value Object containing the configuration.
+     */
+    virtual HttpAppFramework &loadConfigJson(const Json::Value &data) = 0;
+
+    /// Load the configuration from a Json::Value Object.
+    /**
+     * @param rvalue reference to a Json::Value object containing the configuration.
+     */
+    virtual HttpAppFramework &loadConfigJson(Json::Value &&data) = 0;
+
     /// Register a HttpSimpleController object into the framework.
     /**
      * @param pathName When the path of a http request is equal to the

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -130,6 +130,14 @@ ConfigLoader::ConfigLoader(const std::string &configFile)
         }
     }
 }
+ConfigLoader::ConfigLoader(const Json::Value &data)
+    : configJsonRoot_(data)
+{
+}
+ConfigLoader::ConfigLoader(Json::Value &&data)
+    : configJsonRoot_(data)
+{
+}
 ConfigLoader::~ConfigLoader()
 {
 }

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -130,8 +130,7 @@ ConfigLoader::ConfigLoader(const std::string &configFile)
         }
     }
 }
-ConfigLoader::ConfigLoader(const Json::Value &data)
-    : configJsonRoot_(data)
+ConfigLoader::ConfigLoader(const Json::Value &data) : configJsonRoot_(data)
 {
 }
 ConfigLoader::ConfigLoader(Json::Value &&data)

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -135,7 +135,7 @@ ConfigLoader::ConfigLoader(const Json::Value &data)
 {
 }
 ConfigLoader::ConfigLoader(Json::Value &&data)
-    : configJsonRoot_(data)
+    : configJsonRoot_(std::move(data))
 {
 }
 ConfigLoader::~ConfigLoader()

--- a/lib/src/ConfigLoader.h
+++ b/lib/src/ConfigLoader.h
@@ -24,6 +24,8 @@ class ConfigLoader : public trantor::NonCopyable
 {
   public:
     explicit ConfigLoader(const std::string &configFile);
+    explicit ConfigLoader(const Json::Value &data);
+    explicit ConfigLoader(Json::Value &&data);
     ~ConfigLoader();
     const Json::Value &jsonValue() const
     {

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -333,16 +333,14 @@ HttpAppFramework &HttpAppFrameworkImpl::loadConfigFile(
     jsonConfig_ = loader.jsonValue();
     return *this;
 }
-HttpAppFramework &HttpAppFrameworkImpl::loadConfigJson(
-    const Json::Value &data)
+HttpAppFramework &HttpAppFrameworkImpl::loadConfigJson(const Json::Value &data)
 {
     ConfigLoader loader(data);
     loader.load();
     jsonConfig_ = loader.jsonValue();
     return *this;
 }
-HttpAppFramework &HttpAppFrameworkImpl::loadConfigJson(
-    Json::Value &&data)
+HttpAppFramework &HttpAppFrameworkImpl::loadConfigJson(Json::Value &&data)
 {
     ConfigLoader loader(std::move(data));
     loader.load();

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -333,6 +333,22 @@ HttpAppFramework &HttpAppFrameworkImpl::loadConfigFile(
     jsonConfig_ = loader.jsonValue();
     return *this;
 }
+HttpAppFramework &HttpAppFrameworkImpl::loadConfigJson(
+    const Json::Value &data)
+{
+    ConfigLoader loader(data);
+    loader.load();
+    jsonConfig_ = loader.jsonValue();
+    return *this;
+}
+HttpAppFramework &HttpAppFrameworkImpl::loadConfigJson(
+    Json::Value &&data)
+{
+    ConfigLoader loader(std::move(data));
+    loader.load();
+    jsonConfig_ = loader.jsonValue();
+    return *this;
+}
 HttpAppFramework &HttpAppFrameworkImpl::setLogPath(
     const std::string &logPath,
     const std::string &logfileBaseName,

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -17,6 +17,7 @@
 #include "impl_forwards.h"
 #include <drogon/HttpAppFramework.h>
 #include <drogon/config.h>
+#include <json/json.h>
 #include <memory>
 #include <mutex>
 #include <regex>
@@ -248,6 +249,10 @@ class HttpAppFrameworkImpl : public HttpAppFramework
         size_t maxConnectionsPerIP) override;
     virtual HttpAppFramework &loadConfigFile(
         const std::string &fileName) override;
+    virtual HttpAppFramework &loadConfigJson(
+        const Json::Value &data) override;
+    virtual HttpAppFramework &loadConfigJson(
+        Json::Value &&data) override;
     virtual HttpAppFramework &enableRunAsDaemon() override
     {
         runAsDaemon_ = true;

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -249,10 +249,8 @@ class HttpAppFrameworkImpl : public HttpAppFramework
         size_t maxConnectionsPerIP) override;
     virtual HttpAppFramework &loadConfigFile(
         const std::string &fileName) override;
-    virtual HttpAppFramework &loadConfigJson(
-        const Json::Value &data) override;
-    virtual HttpAppFramework &loadConfigJson(
-        Json::Value &&data) override;
+    virtual HttpAppFramework &loadConfigJson(const Json::Value &data) override;
+    virtual HttpAppFramework &loadConfigJson(Json::Value &&data) override;
     virtual HttpAppFramework &enableRunAsDaemon() override
     {
         runAsDaemon_ = true;


### PR DESCRIPTION
The new functions skip the file reading logic an directly supplys the `configJsonRoot_` member with the json data. The `configFile` member is uninitialized as it is not needed by anything in the program and no file exists that ist could name.

fix #578