### PR TITLE
Fix HttpServer::isWebSocket to detect lowercase "upgrade" connection value

### DIFF
--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -105,7 +105,12 @@ static bool isWebSocket(const HttpRequestImplPtr &req)
     if (headers.find("upgrade") == headers.end() ||
         headers.find("connection") == headers.end())
         return false;
-    if (req->getHeaderBy("connection").find("Upgrade") != std::string::npos &&
+    auto connectionField = req->getHeaderBy("connection");
+    std::transform(connectionField.begin(),
+                   connectionField.end(),
+                   connectionField.begin(),
+                   tolower);
+    if (connectionField.find("upgrade") != std::string::npos &&
         req->getHeaderBy("upgrade") == "websocket")
     {
         LOG_TRACE << "new websocket request";

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -110,8 +110,13 @@ static bool isWebSocket(const HttpRequestImplPtr &req)
                    connectionField.end(),
                    connectionField.begin(),
                    tolower);
+    auto upgradeField = req->getHeaderBy("upgrade");
+    std::transform(upgradeField.begin(),
+                   upgradeField.end(),
+                   upgradeField.begin(),
+                   tolower);
     if (connectionField.find("upgrade") != std::string::npos &&
-        req->getHeaderBy("upgrade") == "websocket")
+        upgradeField == "websocket")
     {
         LOG_TRACE << "new websocket request";
 


### PR DESCRIPTION
The websocket library boost-beast sends the following http header: 'Connection: upgrade', 
while almost anything else uses: 'Connection: Upgrade'. 
Drogon used to only recognize the latter as websocket request, now it recognizes both.

It took me quite a long time to figure this out, because any other client I tested could connect to drogon
and I could connect beast to any other server except drogon. This fix will probably hurt performance, but
I think it's still a good change. An alternative fix would be to also check for the value "upgrade" (with a lowercase 'u').

I haven't looked up who is right in this case, but I assume boost-beast is.