### PR TITLE
Don't send content type in a 304 response

### DIFF
--- a/lib/src/HttpUtils.cc
+++ b/lib/src/HttpUtils.cc
@@ -147,6 +147,11 @@ const string_view &webContentTypeToString(ContentType contenttype)
             static string_view sv = "Content-Type: application/wasm\r\n";
             return sv;
         }
+        case CT_NONE:
+        {
+            static string_view sv = "";
+            return sv;
+        }
         default:
         case CT_TEXT_PLAIN:
         {

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -223,6 +223,7 @@ void StaticFileRouter::sendStaticFileResponse(
                 std::shared_ptr<HttpResponseImpl> resp =
                     std::make_shared<HttpResponseImpl>();
                 resp->setStatusCode(k304NotModified);
+                resp->setContentTypeCode(CT_NONE);
                 HttpAppFrameworkImpl::instance().callCallback(req,
                                                               resp,
                                                               callback);
@@ -258,6 +259,7 @@ void StaticFileRouter::sendStaticFileResponse(
                     std::shared_ptr<HttpResponseImpl> resp =
                         std::make_shared<HttpResponseImpl>();
                     resp->setStatusCode(k304NotModified);
+                    resp->setContentTypeCode(CT_NONE);
                     HttpAppFrameworkImpl::instance().callCallback(req,
                                                                   resp,
                                                                   callback);


### PR DESCRIPTION
Makes that 304 sent by the static file router doesn't contain a `Content-Type` header. Otherwise it messes with Chrome's response preview.

Before this PR
![image](https://user-images.githubusercontent.com/8792393/99499108-59f44e80-29b3-11eb-8919-67be5dd4da20.png)

After:
![image](https://user-images.githubusercontent.com/8792393/99499146-6a0c2e00-29b3-11eb-8cf5-385dae3c8a40.png)

Not sure if changing `webContentTypeToString` is the best way. Let me know if there's something I should change