### PR TITLE
Add implicit page resolving capability (a-directory -> a-directory/index.html)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -74,7 +74,7 @@
         "use_implicit_page": true,
         //implicit_page: Set the file which would the server access in a directory that a user accessed.
         //For example, by default, http://localhost/a-directory resolves to http://localhost/a-directory/index.html.
-        "implicit_page": "page.html",
+        "implicit_page": "index.html",
         //static_file_headers: Headers for static files
         /*"static_file_headers": [
           {

--- a/config.example.json
+++ b/config.example.json
@@ -70,6 +70,11 @@
         //If there isn't any handler registered to the path "/", the home page file in the "document_root" is send to clients as a response
         //to the request for "/".
         "home_page": "index.html",
+        //use_implicit_page: enable implicit pages if true, true by default
+        "use_implicit_page": true,
+        //implicit_page: Set the file which would the server access in a directory that a user accessed.
+        //For example, by default, http://localhost/a-directory resolves to http://localhost/a-directory/index.html.
+        "implicit_page": "page.html",
         //static_file_headers: Headers for static files
         /*"static_file_headers": [
           {

--- a/drogon_ctl/templates/config.csp
+++ b/drogon_ctl/templates/config.csp
@@ -70,6 +70,11 @@
         //If there isn't any handler registered to the path "/", the home page file in the "document_root" is send to clients as a response
         //to the request for "/".
         "home_page": "index.html",
+        //use_implicit_page: enable implicit pages if true, true by default
+        "use_implicit_page": true,
+        //implicit_page: Set the file which would the server access in a directory that a user accessed.
+        //For example, by default, http://localhost/a-directory resolves to http://localhost/a-directory/index.html.
+        "implicit_page": "index.html",
         //static_file_headers: Headers for static files
         /*"static_file_headers": [
           {

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,7 +19,8 @@ set(simple_example_sources
     simple_example/main.cc)
 
 add_executable(webapp ${simple_example_sources})
-drogon_create_views(webapp ${CMAKE_CURRENT_SOURCE_DIR}/simple_example ${CMAKE_CURRENT_BINARY_DIR})
+drogon_create_views(webapp ${CMAKE_CURRENT_SOURCE_DIR}/simple_example
+                    ${CMAKE_CURRENT_BINARY_DIR})
 add_dependencies(webapp drogon_ctl)
 
 set(client_example_sources client_example/main.cc)
@@ -43,10 +44,15 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/drogon.jpg
           ${CMAKE_CURRENT_SOURCE_DIR}/simple_example/index.html
           ${CMAKE_CURRENT_SOURCE_DIR}/simple_example/index.html.gz
-          ${CMAKE_CURRENT_SOURCE_DIR}/simple_example/a-directory/page.html
           ${PROJECT_SOURCE_DIR}/trantor/trantor/tests/server.pem
           $<TARGET_FILE_DIR:webapp>)
-
+add_custom_command(
+  TARGET webapp POST_BUILD
+  COMMAND ${CMAKE_COMMAND}
+          -E
+          copy_directory
+          ${CMAKE_CURRENT_SOURCE_DIR}/simple_example/a-directory
+          $<TARGET_FILE_DIR:webapp>/a-directory)
 set(example_targets
     webapp
     webapp_test

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,6 +43,7 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/drogon.jpg
           ${CMAKE_CURRENT_SOURCE_DIR}/simple_example/index.html
           ${CMAKE_CURRENT_SOURCE_DIR}/simple_example/index.html.gz
+          ${CMAKE_CURRENT_SOURCE_DIR}/simple_example/a-directory/page.html
           ${PROJECT_SOURCE_DIR}/trantor/trantor/tests/server.pem
           $<TARGET_FILE_DIR:webapp>)
 

--- a/examples/simple_example/a-directory/page.html
+++ b/examples/simple_example/a-directory/page.html
@@ -1,0 +1,187 @@
+<p><img src="https://github.com/an-tao/drogon/wiki/images/drogon-white.jpg" alt="" /></p>
+
+<p><a href="https://travis-ci.com/an-tao/drogon"><img src="https://travis-ci.com/an-tao/drogon.svg?branch=master" alt="Build Status" /></a>
+<a href="https://app.codacy.com/app/an-tao/drogon?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=an-tao/drogon&amp;utm_campaign=Badge_Grade_Dashboard"><img src="https://api.codacy.com/project/badge/Grade/45f8a65ca1844788b9109c0044a618f8" alt="Codacy Badge" /></a>
+<a href="https://lgtm.com/projects/g/an-tao/drogon/alerts/"><img src="https://img.shields.io/lgtm/alerts/g/an-tao/drogon.svg?logo=lgtm&amp;logoWidth=18" alt="Total alerts" /></a>
+<a href="https://lgtm.com/projects/g/an-tao/drogon/context:cpp"><img src="https://img.shields.io/lgtm/grade/cpp/g/an-tao/drogon.svg?logo=lgtm&amp;logoWidth=18" alt="Language grade: C/C++" /></a> 
+<a href="https://gitter.im/drogon-web/community?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://badges.gitter.im/drogon-web/community.svg" alt="Join the chat at https://gitter.im/drogon-web/community" /></a>
+<a href="https://cloud.docker.com/u/drogonframework/repository/docker/drogonframework/drogon"><img src="https://img.shields.io/badge/Docker-image-blue.svg" alt="Docker image" /></a></p>
+
+<h3 id="overview">Overview (from an implicit page)</h3>
+<p><strong>Drogon</strong> is a C++14/17-based HTTP application framework. Drogon can be used to easily build various types of web application server programs using C++. <strong>Drogon</strong> is the name of a dragon in the American TV series “Game of Thrones” that I really like.</p>
+
+<p>Drogon’s main application platform is Linux. It also supports Mac OS and FreeBSD. Currently, it does not support windows. Its main features are as follows:</p>
+
+<ul>
+  <li>Use a non-blocking I/O network lib based on epoll (kqueue under MacOS/FreeBSD) to provide high-concurrency, high-performance network IO, please visit the <a href="https://github.com/an-tao/drogon/wiki/benchmarks">benchmarks</a> page for more details;</li>
+  <li>Provide a completely asynchronous programming mode;</li>
+  <li>Support Http1.0/1.1 (server side and client side);</li>
+  <li>Based on template, a simple reflection mechanism is implemented to completely decouple the main program framework, controllers and views.</li>
+  <li>Support cookies and built-in sessions;</li>
+  <li>Support back-end rendering, the controller generates the data to the view to generate the Html page, the view is described by a “JSP-like” CSP file, the C++ code is embedded into the Html page by the CSP tag, and the drogon command-line tool automatically generates the C++ code file for compilation;</li>
+  <li>Support view page dynamic loading (dynamic compilation and loading at runtime);</li>
+  <li>Provide a convenient and flexible routing solution from the path to the controller handler;</li>
+  <li>Support filter chains to facilitate the execution of unified logic (such as login verification, Http Method constraint verification, etc.) before controllers;</li>
+  <li>Support https (based on OpenSSL);</li>
+  <li>Support WebSocket (server side and client side);</li>
+  <li>Support JSON format request and response, very friendly to the Restful API application development;</li>
+  <li>Support file download and upload;</li>
+  <li>Support gzip compression transmission;</li>
+  <li>Support pipelining;</li>
+  <li>Provide a lightweight command line tool, drogon_ctl, to simplify the creation of various classes in Drogon and the generation of view code;</li>
+  <li>Support non-blocking I/O based asynchronously reading and writing database (PostgreSQL and MySQL(MariaDB) database);</li>
+  <li>Support asynchronously reading and writing sqlite3 database based on thread pool;</li>
+  <li>Support ARM Architecture;</li>
+  <li>Provide a convenient lightweight ORM implementation that supports for regular object-to-database bidirectional mapping;</li>
+  <li>Support plugins which can be installed by the configuration file at load time;</li>
+  <li>Support AOP with build-in joinpoints.</li>
+</ul>
+
+<h2 id="a-very-simple-example">A very simple example</h2>
+
+<p>Unlike most C++ frameworks, the main program of the drogon application can be kept clean and simple. Drogon uses a few tricks to decouple controllers from the main program. The routing settings of controllers can be done through macros or configuration file.</p>
+
+<p>Below is the main program of a typical drogon application:</p>
+
+<p><code>c++
+#include &lt;drogon/drogon.h&gt;
+using namespace drogon;
+int main()
+{
+    app().setLogPath("./");
+    app().setLogLevel(trantor::Logger::kWarn);
+    app().addListener("0.0.0.0", 80);
+    app().setThreadNum(16);
+    app().enableRunAsDaemon();
+    app().run();
+}
+</code></p>
+
+<p>It can be further simplified by using configuration file as follows:</p>
+
+<p><code>c++
+#include &lt;drogon/drogon.h&gt;
+using namespace drogon;
+int main()
+{
+    app().loadConfigFile("./config.json");
+    app().run();
+}
+</code></p>
+
+<p>Drogon provides some interfaces for adding controller logic directly in the main() function, for example, user can register a handler like this in Drogon:</p>
+
+<p><code>c++
+app.registerHandler("/test?username={1}",
+                    [](const HttpRequestPtr&amp; req,
+                       const std::function&lt;void (const HttpResponsePtr &amp;)&gt; &amp; callback,
+                       const std::string &amp;name)
+                    {
+                        Json::Value json;
+                        json["result"]="ok";
+                        json["message"]=std::string("hello,")+name;
+                        auto resp=HttpResponse::newHttpJsonResponse(json);
+                        callback(resp);
+                    },
+                    {Get,"LoginFilter"});
+</code></p>
+
+<p>While such interfaces look intuitive, they are not suitable for complex business logic scenarios. Assuming there are tens or even hundreds of handlers that need to be registered in the framework, isn’t it a better practice to implement them separately in their respective classes? So unless your logic is very simple, we don’t recommend using above interfaces. Instead, we can create an HttpSimpleController as follows:</p>
+
+<p>```c++
+/// The TestCtrl.h file
+#pragma once
+#include &lt;drogon/HttpSimpleController.h&gt;
+using namespace drogon;
+class TestCtrl:public drogon::HttpSimpleController<testctrl>
+{
+public:
+    virtual void asyncHandleHttpRequest(const HttpRequestPtr&amp; req,const std::function&lt;void (const HttpResponsePtr &amp;)&gt; &amp; callback)override;
+    PATH_LIST_BEGIN
+    PATH_ADD("/test",Get);
+    PATH_LIST_END
+};</testctrl></p>
+
+<p>/// The TestCtrl.cc file
+#include “TestCtrl.h”
+void TestCtrl::asyncHandleHttpRequest(const HttpRequestPtr&amp; req,
+                                      const std::function&lt;void (const HttpResponsePtr &amp;)&gt; &amp; callback)
+{
+    //write your application logic here
+    auto resp = HttpResponse::newHttpResponse();
+    resp-&gt;setBody(“&lt;p&gt;Hello, world!&lt;/p&gt;”);
+    resp-&gt;setExpiredTime(0);
+    callback(resp);
+}
+```</p>
+
+<p><strong>Most of the above programs can be automatically generated by the command line tool <code>drogon_ctl</code> provided by drogon</strong> (The cammand is <code>drogon_ctl create controller TestCtrl</code>). All the user needs to do is add their own business logic. In the example, the controller returns a <code>Hello, world!</code> string when the client accesses the <code>http://ip/test</code> URL.</p>
+
+<p>For JSON format response, we create the controller as follows:</p>
+
+<p>```c++
+/// The header file
+#pragma once
+#include &lt;drogon/HttpSimpleController.h&gt;
+using namespace drogon;
+class JsonCtrl : public drogon::HttpSimpleController<jsonctrl>
+{
+  public:
+    virtual void asyncHandleHttpRequest(const HttpRequestPtr &amp;req, const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback) override;
+    PATH_LIST_BEGIN
+    //list path definitions here;
+    PATH_ADD("/json", Get);
+    PATH_LIST_END
+};</jsonctrl></p>
+
+<p>/// The source file
+#include “JsonCtrl.h”
+void JsonCtrl::asyncHandleHttpRequest(const HttpRequestPtr &amp;req,
+                                      const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback)
+{
+    Json::Value ret;
+    ret[“message”] = “Hello, World!”;
+    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    callback(resp);
+}
+```</p>
+
+<p>Let’s go a step further and create a demo RESTful API with the HttpController class, as shown below (Omit the source file):</p>
+
+<p><code>c++
+/// The header file
+#pragma once
+#include &lt;drogon/HttpController.h&gt;
+using namespace drogon;
+namespace api
+{
+namespace v1
+{
+class User : public drogon::HttpController&lt;User&gt;
+{
+  public:
+    METHOD_LIST_BEGIN
+    //use METHOD_ADD to add your custom processing function here;
+    METHOD_ADD(User::getInfo, "/{1}", Get);                  //path is /api/v1/User/{arg1}
+    METHOD_ADD(User::getDetailInfo, "/{1}/detailinfo", Get);  //path is /api/v1/User/{arg1}/detailinfo
+    METHOD_ADD(User::newUser, "/{1}", Post);                 //path is /api/v1/User/{arg1}
+    METHOD_LIST_END
+    //your declaration of processing function maybe like this:
+    void getInfo(const HttpRequestPtr &amp;req, const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback, int userId) const;
+    void getDetailInfo(const HttpRequestPtr &amp;req, const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback, int userId) const;
+    void newUser(const HttpRequestPtr &amp;req, const std::function&lt;void(const HttpResponsePtr &amp;)&gt; &amp;callback, std::string &amp;&amp;userName);
+  public:
+    User()
+    {
+        LOG_DEBUG &lt;&lt; "User constructor!";
+    }
+};
+} // namespace v1
+} // namespace api
+</code></p>
+
+<p>As you can see, users can use the <code>HttpController</code> to map paths and parameters at the same time. This is a very convenient way to create a RESTful API application.</p>
+
+<p>In addition, you can also find that all handler interfaces are in asynchronous mode, where the response is returned by a callback object. This design is for performance reasons because in asynchronous mode the drogon application can handle a large number of concurrent requests with a small number of threads.</p>
+
+<p>After compiling all of the above source files, we get a very simple web application. This is a good start. <strong>for more information, please visit the <a href="https://github.com/an-tao/drogon/wiki">wiki</a> site</strong></p>

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -207,8 +207,6 @@ int main()
     app().registerHandler("/api/v1/handle4/{4:p4}/{3:p3}/{1:p1}", func);
 
     app().setDocumentRoot("./");
-    app().setImplicitPageEnable(true);
-    app().setImplicitPage("page.html");
     app().enableSession(60);
 
     std::map<std::string, std::string> config_credentials;
@@ -216,6 +214,8 @@ int main()
     std::string opaque("drogonOpaque");
     // Load configuration
     app().loadConfigFile("config.example.json");
+    app().setImplicitPageEnable(true);
+    app().setImplicitPage("page.html");
     auto &json = app().getCustomConfig();
     if (json.empty())
     {

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -207,6 +207,8 @@ int main()
     app().registerHandler("/api/v1/handle4/{4:p4}/{3:p3}/{1:p1}", func);
 
     app().setDocumentRoot("./");
+    app().setImplicitPageEnable(true);
+    app().setImplicitPage("page.html");
     app().enableSession(60);
 
     std::map<std::string, std::string> config_credentials;

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -20,6 +20,7 @@
 
 #include <mutex>
 #include <future>
+#include <filesystem>
 #ifndef _WIN32
 #include <unistd.h>
 #endif
@@ -29,8 +30,8 @@
 #define GREEN "\033[32m" /* Green */
 
 #define JPG_LEN 44618
-#define INDEX_LEN 10606
-#define INDEX_IMPLICIT_LEN 10630
+size_t indexLen;
+size_t indexImplicitLen;
 
 using namespace drogon;
 
@@ -861,7 +862,7 @@ void doTest(const HttpClientPtr &client,
                                        const HttpResponsePtr &resp) {
                             if (result == ReqResult::Ok)
                             {
-                                if (resp->getBody().length() == INDEX_LEN)
+                                if (resp->getBody().length() == indexLen)
                                 {
                                     outputGood(req, isHttps);
                                 }
@@ -888,7 +889,7 @@ void doTest(const HttpClientPtr &client,
                                        const HttpResponsePtr &resp) {
                             if (result == ReqResult::Ok)
                             {
-                                if (resp->getBody().length() == INDEX_LEN)
+                                if (resp->getBody().length() == indexLen)
                                 {
                                     outputGood(req, isHttps);
                                 }
@@ -1163,7 +1164,7 @@ void doTest(const HttpClientPtr &client,
                             if (result == ReqResult::Ok)
                             {
                                 if (resp->getBody().length() ==
-                                    INDEX_IMPLICIT_LEN)
+                                    indexImplicitLen)
                                 {
                                     body = resp->getBody();
                                     outputGood(req, isHttps);
@@ -1191,7 +1192,7 @@ void doTest(const HttpClientPtr &client,
                             if (result == ReqResult::Ok)
                             {
                                 if (resp->getBody().length() ==
-                                        INDEX_IMPLICIT_LEN &&
+                                        indexImplicitLen &&
                                     body == resp->getBody())
                                 {
                                     outputGood(req, isHttps);
@@ -1245,6 +1246,16 @@ void doTest(const HttpClientPtr &client,
             }
         });
 }
+void loadFileLengths()
+{
+    try{
+        indexLen = std::filesystem::file_size("index.html");
+        indexImplicitLen = std::filesystem::file_size("a-directory/page.html");
+    }catch(std::exception e){
+        LOG_ERROR << "Unable to retrieve HTML file sizes: " << e.what();
+        exit(1);
+    }
+}
 int main(int argc, char *argv[])
 {
     trantor::EventLoopThread loop[2];
@@ -1254,7 +1265,7 @@ int main(int argc, char *argv[])
         ever = true;
     loop[0].run();
     loop[1].run();
-
+    loadFileLengths();
     do
     {
         std::promise<int> pro1;

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -30,6 +30,7 @@
 
 #define JPG_LEN 44618
 #define INDEX_LEN 10606
+#define INDEX_IMPLICIT_LEN 10817
 
 using namespace drogon;
 
@@ -1142,6 +1143,61 @@ void doTest(const HttpClientPtr &client,
                                 {
                                     LOG_DEBUG << resp->getBody().length();
                                     LOG_ERROR << "Error!";
+                                    exit(1);
+                                }
+                            }
+                            else
+                            {
+                                LOG_ERROR << "Error!";
+                                exit(1);
+                            }
+                        });
+    //Test implicit pages
+    std::string body;
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/a-directory");
+    client->sendRequest(req,
+                        [req, isHttps, &body](ReqResult result,
+                                       const HttpResponsePtr &resp) {
+                            if (result == ReqResult::Ok)
+                            {
+                                if (resp->getBody().length() == INDEX_IMPLICIT_LEN)
+                                {
+                                    body = resp->getBody();
+                                    outputGood(req, isHttps);
+                                }
+                                else
+                                {
+                                    LOG_DEBUG << resp->getBody().length();
+                                    LOG_ERROR << "Error!";
+                                    LOG_ERROR << resp->getBody();
+                                    exit(1);
+                                }
+                            }
+                            else
+                            {
+                                LOG_ERROR << "Error!";
+                                exit(1);
+                            }
+                        });
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/a-directory/page.html");
+    client->sendRequest(req,
+                        [req, isHttps, body](ReqResult result,
+                                       const HttpResponsePtr &resp) {
+                            if (result == ReqResult::Ok)
+                            {
+                                if (resp->getBody().length() == INDEX_IMPLICIT_LEN && body == resp->getBody())
+                                {
+                                    outputGood(req, isHttps);
+                                }
+                                else
+                                {
+                                    LOG_DEBUG << resp->getBody().length();
+                                    LOG_ERROR << "Error!";
+                                    LOG_ERROR << resp->getBody();
                                     exit(1);
                                 }
                             }

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -1248,10 +1248,13 @@ void doTest(const HttpClientPtr &client,
 }
 void loadFileLengths()
 {
-    try{
+    try
+    {
         indexLen = std::filesystem::file_size("index.html");
         indexImplicitLen = std::filesystem::file_size("a-directory/page.html");
-    }catch(std::exception e){
+    }
+    catch (std::exception e)
+    {
         LOG_ERROR << "Unable to retrieve HTML file sizes: " << e.what();
         exit(1);
     }

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -30,7 +30,7 @@
 
 #define JPG_LEN 44618
 #define INDEX_LEN 10606
-#define INDEX_IMPLICIT_LEN 10817
+#define INDEX_IMPLICIT_LEN 10630
 
 using namespace drogon;
 
@@ -1152,17 +1152,18 @@ void doTest(const HttpClientPtr &client,
                                 exit(1);
                             }
                         });
-    //Test implicit pages
+    // Test implicit pages
     std::string body;
     req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);
     req->setPath("/a-directory");
     client->sendRequest(req,
                         [req, isHttps, &body](ReqResult result,
-                                       const HttpResponsePtr &resp) {
+                                              const HttpResponsePtr &resp) {
                             if (result == ReqResult::Ok)
                             {
-                                if (resp->getBody().length() == INDEX_IMPLICIT_LEN)
+                                if (resp->getBody().length() ==
+                                    INDEX_IMPLICIT_LEN)
                                 {
                                     body = resp->getBody();
                                     outputGood(req, isHttps);
@@ -1185,11 +1186,13 @@ void doTest(const HttpClientPtr &client,
     req->setMethod(drogon::Get);
     req->setPath("/a-directory/page.html");
     client->sendRequest(req,
-                        [req, isHttps, body](ReqResult result,
-                                       const HttpResponsePtr &resp) {
+                        [req, isHttps, &body](ReqResult result,
+                                              const HttpResponsePtr &resp) {
                             if (result == ReqResult::Ok)
                             {
-                                if (resp->getBody().length() == INDEX_IMPLICIT_LEN && body == resp->getBody())
+                                if (resp->getBody().length() ==
+                                        INDEX_IMPLICIT_LEN &&
+                                    body == resp->getBody())
                                 {
                                     outputGood(req, isHttps);
                                 }

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1067,6 +1067,42 @@ class HttpAppFramework : public trantor::NonCopyable
      */
     virtual const std::string &getHomePage() const = 0;
 
+    /// Set to enable implicit pages, enabled by default
+    /**
+     * @brief Implicit pages are used when the server detects if the user requested a directory.
+     * By default, it will try to append index.html to the path, see setImplicitPage() if you
+     * want to customize this 
+     * (http://localhost/a-directory resolves to http://localhost/a-directory/index.html by default).
+     * 
+     * @note
+     * This operation can be performed by an option in the configuration file.
+     */
+    virtual HttpAppFramework &setImplicitPageEnable(bool useImplicitPage) = 0;
+
+    /// Return true if implicit pages are enabled
+    /**
+     * @note
+     * This method must be called after the framework has been run.
+     */
+    virtual bool isImplicitPageEnabled() const = 0;
+
+    /// Set the HTML file that a directory would resolve to by default, default is "index.html"
+    /**
+     * @brief Sets the page which would the server load in if it detects that the user
+     * requested a directory
+     * 
+     * @note
+     * This operation can be performed by an option in the configuration file.
+     */
+    virtual HttpAppFramework &setImplicitPage(const std::string &implicitPageFile) = 0;
+
+    /// Get the implicit HTML page
+    /**
+     * @note
+     * This method must be called after the framework has been run.
+     */
+    virtual const std::string &getImplicitPage() const = 0;
+
     /// Get a database client by name
     /**
      * @note

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -1069,11 +1069,12 @@ class HttpAppFramework : public trantor::NonCopyable
 
     /// Set to enable implicit pages, enabled by default
     /**
-     * @brief Implicit pages are used when the server detects if the user requested a directory.
-     * By default, it will try to append index.html to the path, see setImplicitPage() if you
-     * want to customize this 
-     * (http://localhost/a-directory resolves to http://localhost/a-directory/index.html by default).
-     * 
+     * @brief Implicit pages are used when the server detects if the user
+     * requested a directory. By default, it will try to append index.html to
+     * the path, see setImplicitPage() if you want to customize this
+     * (http://localhost/a-directory resolves to
+     * http://localhost/a-directory/index.html by default).
+     *
      * @note
      * This operation can be performed by an option in the configuration file.
      */
@@ -1086,15 +1087,17 @@ class HttpAppFramework : public trantor::NonCopyable
      */
     virtual bool isImplicitPageEnabled() const = 0;
 
-    /// Set the HTML file that a directory would resolve to by default, default is "index.html"
+    /// Set the HTML file that a directory would resolve to by default, default
+    /// is "index.html"
     /**
-     * @brief Sets the page which would the server load in if it detects that the user
-     * requested a directory
-     * 
+     * @brief Sets the page which would the server load in if it detects that
+     * the user requested a directory
+     *
      * @note
      * This operation can be performed by an option in the configuration file.
      */
-    virtual HttpAppFramework &setImplicitPage(const std::string &implicitPageFile) = 0;
+    virtual HttpAppFramework &setImplicitPage(
+        const std::string &implicitPageFile) = 0;
 
     /// Get the implicit HTML page
     /**

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -454,8 +454,10 @@ static void loadApp(const Json::Value &app)
     }
     drogon::app().enableReusePort(app.get("reuse_port", false).asBool());
     drogon::app().setHomePage(app.get("home_page", "index.html").asString());
-    drogon::app().setImplicitPageEnable(app.get("use_implicit_page", true).asBool());
-    drogon::app().setImplicitPage(app.get("implicit_page", "index.html").asString());
+    drogon::app().setImplicitPageEnable(
+        app.get("use_implicit_page", true).asBool());
+    drogon::app().setImplicitPage(
+        app.get("implicit_page", "index.html").asString());
 }
 static void loadDbClients(const Json::Value &dbClients)
 {

--- a/lib/src/ConfigLoader.cc
+++ b/lib/src/ConfigLoader.cc
@@ -454,6 +454,8 @@ static void loadApp(const Json::Value &app)
     }
     drogon::app().enableReusePort(app.get("reuse_port", false).asBool());
     drogon::app().setHomePage(app.get("home_page", "index.html").asString());
+    drogon::app().setImplicitPageEnable(app.get("use_implicit_page", true).asBool());
+    drogon::app().setImplicitPage(app.get("implicit_page", "index.html").asString());
 }
 static void loadDbClients(const Json::Value &dbClients)
 {

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -192,6 +192,24 @@ HttpAppFramework &HttpAppFrameworkImpl::setBrStatic(bool useGzipStatic)
     staticFileRouterPtr_->setBrStatic(useGzipStatic);
     return *this;
 }
+HttpAppFramework& HttpAppFrameworkImpl::setImplicitPageEnable(bool useImplicitPage)
+{
+    staticFileRouterPtr_->setImplicitPageEnable(useImplicitPage);
+    return *this;
+}
+bool HttpAppFrameworkImpl::isImplicitPageEnabled() const
+{
+    return staticFileRouterPtr_->isImplicitPageEnabled();
+}
+HttpAppFramework& HttpAppFrameworkImpl::setImplicitPage(const std::string &implicitPageFile)
+{
+    staticFileRouterPtr_->setImplicitPage(implicitPageFile);
+    return *this;
+}
+const std::string& HttpAppFrameworkImpl::getImplicitPage() const
+{
+    return staticFileRouterPtr_->getImplicitPage();
+}
 #ifndef _WIN32
 HttpAppFramework &HttpAppFrameworkImpl::enableDynamicViewsLoading(
     const std::vector<std::string> &libPaths,

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -192,7 +192,8 @@ HttpAppFramework &HttpAppFrameworkImpl::setBrStatic(bool useGzipStatic)
     staticFileRouterPtr_->setBrStatic(useGzipStatic);
     return *this;
 }
-HttpAppFramework& HttpAppFrameworkImpl::setImplicitPageEnable(bool useImplicitPage)
+HttpAppFramework &HttpAppFrameworkImpl::setImplicitPageEnable(
+    bool useImplicitPage)
 {
     staticFileRouterPtr_->setImplicitPageEnable(useImplicitPage);
     return *this;
@@ -201,12 +202,13 @@ bool HttpAppFrameworkImpl::isImplicitPageEnabled() const
 {
     return staticFileRouterPtr_->isImplicitPageEnabled();
 }
-HttpAppFramework& HttpAppFrameworkImpl::setImplicitPage(const std::string &implicitPageFile)
+HttpAppFramework &HttpAppFrameworkImpl::setImplicitPage(
+    const std::string &implicitPageFile)
 {
     staticFileRouterPtr_->setImplicitPage(implicitPageFile);
     return *this;
 }
-const std::string& HttpAppFrameworkImpl::getImplicitPage() const
+const std::string &HttpAppFrameworkImpl::getImplicitPage() const
 {
     return staticFileRouterPtr_->getImplicitPage();
 }

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -348,6 +348,10 @@ class HttpAppFrameworkImpl : public HttpAppFramework
     {
         return termSignalHandler_;
     }
+    virtual HttpAppFramework &setImplicitPageEnable(bool useImplicitPage) override;
+    bool isImplicitPageEnabled() const override;
+    virtual HttpAppFramework &setImplicitPage(const std::string &implicitPageFile) override;
+    const std::string &getImplicitPage() const override;
     size_t getClientMaxBodySize() const
     {
         return clientMaxBodySize_;

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -348,9 +348,11 @@ class HttpAppFrameworkImpl : public HttpAppFramework
     {
         return termSignalHandler_;
     }
-    virtual HttpAppFramework &setImplicitPageEnable(bool useImplicitPage) override;
+    virtual HttpAppFramework &setImplicitPageEnable(
+        bool useImplicitPage) override;
     bool isImplicitPageEnabled() const override;
-    virtual HttpAppFramework &setImplicitPage(const std::string &implicitPageFile) override;
+    virtual HttpAppFramework &setImplicitPage(
+        const std::string &implicitPageFile) override;
     const std::string &getImplicitPage() const override;
     size_t getClientMaxBodySize() const
     {

--- a/lib/src/HttpControllersRouter.cc
+++ b/lib/src/HttpControllersRouter.cc
@@ -22,13 +22,6 @@
 #include <algorithm>
 #include <cctype>
 #include <deque>
-#ifndef _WIN32
-#include <sys/file.h>
-#else
-#define stat _stati64
-#define S_ISDIR(m) (((m)&0170000) == (0040000))
-#endif
-#include <sys/stat.h>
 
 using namespace drogon;
 
@@ -43,30 +36,6 @@ void HttpControllersRouter::doWhenNoHandlerFound(
         HttpAppFrameworkImpl::instance().forward(req, std::move(callback));
         return;
     }
-
-    //Check if path is eligible for an implicit index.html
-    std::string path = req->path();
-    auto pos = path.rfind('.');
-    if (pos == std::string::npos) 
-    {
-        req->setPath(path + "/index.html");
-        HttpAppFrameworkImpl::instance().forward(req, std::move(callback));
-        return;
-    }
-    else
-    {
-        std::string checkIfDirPath = 
-            HttpAppFrameworkImpl::instance().getDocumentRoot() + req->path();
-        struct stat fileStat;
-        if(stat(checkIfDirPath.c_str(), &fileStat) == 0 &&
-            S_ISDIR(fileStat.st_mode))
-        {
-            req->setPath(path + "/index.html");
-            HttpAppFrameworkImpl::instance().forward(req, std::move(callback));
-            return;
-        }
-    }
-
     fileRouter_.route(req, std::move(callback));
 }
 

--- a/lib/src/HttpControllersRouter.cc
+++ b/lib/src/HttpControllersRouter.cc
@@ -22,6 +22,13 @@
 #include <algorithm>
 #include <cctype>
 #include <deque>
+#ifndef _WIN32
+#include <sys/file.h>
+#else
+#define stat _stati64
+#define S_ISDIR(m) (((m)&0170000) == (0040000))
+#endif
+#include <sys/stat.h>
 
 using namespace drogon;
 
@@ -36,6 +43,30 @@ void HttpControllersRouter::doWhenNoHandlerFound(
         HttpAppFrameworkImpl::instance().forward(req, std::move(callback));
         return;
     }
+
+    //Check if path is eligible for an implicit index.html
+    std::string path = req->path();
+    auto pos = path.rfind('.');
+    if (pos == std::string::npos) 
+    {
+        req->setPath(path + "/index.html");
+        HttpAppFrameworkImpl::instance().forward(req, std::move(callback));
+        return;
+    }
+    else
+    {
+        std::string checkIfDirPath = 
+            HttpAppFrameworkImpl::instance().getDocumentRoot() + req->path();
+        struct stat fileStat;
+        if(stat(checkIfDirPath.c_str(), &fileStat) == 0 &&
+            S_ISDIR(fileStat.st_mode))
+        {
+            req->setPath(path + "/index.html");
+            HttpAppFrameworkImpl::instance().forward(req, std::move(callback));
+            return;
+        }
+    }
+
     fileRouter_.route(req, std::move(callback));
 }
 

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -121,29 +121,52 @@ void StaticFileRouter::route(
                 callback(app().getCustomErrorHandler()(k403Forbidden));
                 return;
             }
-            if (!location.allowAll_)
+            std::string filePath =
+                location.realLocation_ +
+                std::string{restOfThePath.data(), restOfThePath.length()};
+            struct stat fileStat;
+            if (stat(filePath.c_str(), &fileStat) != 0)
             {
-                pos = restOfThePath.rfind('.');
-                if (pos == string_view::npos)
+                callback(HttpResponse::newNotFoundResponse());
+                return;
+            }
+            if (S_ISDIR(fileStat.st_mode))
+            {
+                // Check if path is eligible for an implicit index.html
+                if (implicitPageEnable_)
                 {
-                    callback(app().getCustomErrorHandler()(k403Forbidden));
-                    return;
+                    filePath = filePath + "/" + implicitPage_;
                 }
-                std::string extension{restOfThePath.data() + pos + 1,
-                                      restOfThePath.length() - pos - 1};
-                std::transform(extension.begin(),
-                               extension.end(),
-                               extension.begin(),
-                               tolower);
-                if (fileTypeSet_.find(extension) == fileTypeSet_.end())
+                else
                 {
                     callback(app().getCustomErrorHandler()(k403Forbidden));
                     return;
                 }
             }
-            std::string filePath =
-                location.realLocation_ +
-                std::string{restOfThePath.data(), restOfThePath.length()};
+            else
+            {
+                if (!location.allowAll_)
+                {
+                    pos = restOfThePath.rfind('.');
+                    if (pos == string_view::npos)
+                    {
+                        callback(app().getCustomErrorHandler()(k403Forbidden));
+                        return;
+                    }
+                    std::string extension{restOfThePath.data() + pos + 1,
+                                          restOfThePath.length() - pos - 1};
+                    std::transform(extension.begin(),
+                                   extension.end(),
+                                   extension.begin(),
+                                   tolower);
+                    if (fileTypeSet_.find(extension) == fileTypeSet_.end())
+                    {
+                        callback(app().getCustomErrorHandler()(k403Forbidden));
+                        return;
+                    }
+                }
+            }
+
             if (location.filters_.empty())
             {
                 sendStaticFileResponse(filePath,
@@ -177,47 +200,45 @@ void StaticFileRouter::route(
         }
     }
 
-    
-    //Check if path is eligible for an implicit index.html
-    if(implicitPageEnable_)
+    std::string directoryPath =
+        HttpAppFrameworkImpl::instance().getDocumentRoot() + path;
+    struct stat fileStat;
+    if (stat(directoryPath.c_str(), &fileStat) == 0)
     {
-        std::string directoryPath = 
-            HttpAppFrameworkImpl::instance().getDocumentRoot() + path;
-        auto pos = path.rfind('.');
-        if (pos == std::string::npos) 
+        if (S_ISDIR(fileStat.st_mode))
         {
-            std::string filePath = 
-                directoryPath + "/" + implicitPage_;
-            sendStaticFileResponse(filePath, req, callback, "");
-            return;
-        }
-        else
-        {
-            struct stat fileStat;
-            if(stat(directoryPath.c_str(), &fileStat) == 0 &&
-                S_ISDIR(fileStat.st_mode))
+            // Check if path is eligible for an implicit index.html
+            if (implicitPageEnable_)
             {
-                std::string filePath = 
-                    directoryPath + "/" + implicitPage_;
+                std::string filePath = directoryPath + "/" + implicitPage_;
                 sendStaticFileResponse(filePath, req, callback, "");
                 return;
             }
             else
             {
-                //This is a normal page
-                std::string filetype = lPath.substr(pos + 1);
-                if (fileTypeSet_.find(filetype) != fileTypeSet_.end())
-                {
-                    // LOG_INFO << "file query!" << path;
-                    std::string filePath =
-                        directoryPath;
-                    sendStaticFileResponse(filePath, req, callback, "");
-                    return;
-                }
+                callback(app().getCustomErrorHandler()(k403Forbidden));
+                return;
+            }
+        }
+        else
+        {
+            // This is a normal page
+            auto pos = path.rfind('.');
+            if (pos == std::string::npos)
+            {
+                callback(app().getCustomErrorHandler()(k403Forbidden));
+                return;
+            }
+            std::string filetype = lPath.substr(pos + 1);
+            if (fileTypeSet_.find(filetype) != fileTypeSet_.end())
+            {
+                // LOG_INFO << "file query!" << path;
+                std::string filePath = directoryPath;
+                sendStaticFileResponse(filePath, req, callback, "");
+                return;
             }
         }
     }
-
     callback(HttpResponse::newNotFoundResponse());
 }
 

--- a/lib/src/StaticFileRouter.h
+++ b/lib/src/StaticFileRouter.h
@@ -89,7 +89,7 @@ class StaticFileRouter
     {
         implicitPage_ = implicitPageFile;
     }
-    const std::string& getImplicitPage() const
+    const std::string &getImplicitPage() const
     {
         return implicitPage_;
     }

--- a/lib/src/StaticFileRouter.h
+++ b/lib/src/StaticFileRouter.h
@@ -77,6 +77,22 @@ class StaticFileRouter
     {
         headers_ = headers;
     }
+    void setImplicitPageEnable(bool useImplicitPage)
+    {
+        implicitPageEnable_ = useImplicitPage;
+    }
+    bool isImplicitPageEnabled() const
+    {
+        return implicitPageEnable_;
+    }
+    void setImplicitPage(const std::string &implicitPageFile)
+    {
+        implicitPage_ = implicitPageFile;
+    }
+    const std::string& getImplicitPage() const
+    {
+        return implicitPage_;
+    }
 
   private:
     std::set<std::string> fileTypeSet_{"html",
@@ -110,6 +126,8 @@ class StaticFileRouter
         IOThreadStorage<std::unordered_map<std::string, HttpResponsePtr>>>
         staticFilesCache_;
     std::vector<std::pair<std::string, std::string>> headers_;
+    bool implicitPageEnable_{true};
+    std::string implicitPage_{"index.html"};
     struct Location
     {
         std::string uriPrefix_;


### PR DESCRIPTION
Adds http://localhost/a-directory -> http://localhost/a-directory/index.html resolving capability. I'm not sure how you call it "officially" :smile:.

It doesn't ask the client to redirect to anywhere, it redirects at the serverside. Not only this makes the url more aesthetically pleasing, but also it's a must have if the pages have been generated by a static generator and you can't configure the generator to point to index.html. 