### PR TITLE
sqlite3: insert into stmtsMap_ as string_view

### DIFF
--- a/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
+++ b/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
@@ -257,7 +257,7 @@ void Sqlite3Connection::execSqlInQueue(
     if (paraNum > 0 && newStmt)
     {
         auto r = stmts_.insert(std::string{sql});
-        stmtsMap_[std::string{r.first->data(), r.first->length()}] = stmtPtr;
+        stmtsMap_[string_view{r.first->data(), r.first->length()}] = stmtPtr;
     }
     rcb(Result(resultPtr));
     idleCb_();


### PR DESCRIPTION
I've been tracing an issue flagged by address sanitizer when running queries against an sqlite3 database. The sanitizer triggered whenever I repeated a query previously run. I can post a more complete example, but essentially, running the method below twice will trigger the sanitizer.
```cpp
void db::create(std::string session_id) {
    *(drogon::app().getDbClient())
        << "insert into t (id) values (?)"
        << session_id;
}
```
I traced the issue down to stmtsMap_ being declared with string_view keys, but is inserted using a temporary std::string.