### PR TITLE
Add default value interface to sqlbinder for mysql and postgresql

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,7 @@ set(ORM_HEADERS
     orm_lib/inc/drogon/orm/ArrayParser.h
     orm_lib/inc/drogon/orm/Criteria.h
     orm_lib/inc/drogon/orm/DbClient.h
+    orm_lib/inc/drogon/orm/DbTypes.h
     orm_lib/inc/drogon/orm/Exception.h
     orm_lib/inc/drogon/orm/Field.h
     orm_lib/inc/drogon/orm/FunctionTraits.h

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -147,5 +147,12 @@ std::string formattedString(const char *format, ...);
  */
 int createPath(const std::string &path);
 
+/// Replace all occurances of from to to inplace
+/**
+ * @param from string to replace
+ * @param to string to replace with
+ */
+void replaceAll(std::string &s, const std::string &from, const std::string &to);
+
 }  // namespace utils
 }  // namespace drogon

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1163,5 +1163,15 @@ std::string getMd5(const char *data, const size_t dataLen)
 #endif
 }
 
+void replaceAll(std::string &s, const std::string &from, const std::string &to)
+{
+    size_t pos = 0;
+    while ((pos = s.find(from, pos)) != std::string::npos)
+    {
+        s.replace(pos, from.size(), to);
+        pos += to.size();
+    }
+}
+
 }  // namespace utils
 }  // namespace drogon

--- a/orm_lib/inc/drogon/orm/DbTypes.h
+++ b/orm_lib/inc/drogon/orm/DbTypes.h
@@ -1,9 +1,9 @@
 /**
  *
  *  @file DbTypes.h
- *  @author An Tao
+ *  @author interfector18
  *
- *  Copyright 2018, An Tao.  All rights reserved.
+ *  Copyright 2020, An Tao.  All rights reserved.
  *  https://github.com/an-tao/drogon
  *  Use of this source code is governed by a MIT license
  *  that can be found in the License file.
@@ -12,8 +12,7 @@
  *
  */
 
-#ifndef DBTYPES_HPP
-#define DBTYPES_HPP
+#pragma once
 
 namespace drogon
 {
@@ -39,5 +38,3 @@ enum FieldType
 }  // namespace internal
 }  // namespace orm
 }  // namespace drogon
-
-#endif  // DBTYPES_HPP

--- a/orm_lib/inc/drogon/orm/DbTypes.h
+++ b/orm_lib/inc/drogon/orm/DbTypes.h
@@ -1,0 +1,39 @@
+/**
+ *
+ *  @file DbTypes.h
+ *  @author An Tao
+ *
+ *  Copyright 2018, An Tao.  All rights reserved.
+ *  https://github.com/an-tao/drogon
+ *  Use of this source code is governed by a MIT license
+ *  that can be found in the License file.
+ *
+ *  Drogon
+ *
+ */
+
+#ifndef DBTYPES_HPP
+#define DBTYPES_HPP
+
+namespace drogon
+{
+namespace orm
+{
+
+class DefaultValue {};
+
+}  // namespace orm
+}  // namespace drogon
+
+enum FieldType
+{
+    MySqlTiny,
+    MySqlShort,
+    MySqlLong,
+    MySqlLongLong,
+    MySqlNull,
+    MySqlString,
+    DrogonDefaultValue,
+};
+
+#endif  // DBTYPES_HPP

--- a/orm_lib/inc/drogon/orm/DbTypes.h
+++ b/orm_lib/inc/drogon/orm/DbTypes.h
@@ -19,8 +19,9 @@ namespace drogon
 {
 namespace orm
 {
-
-class DefaultValue {};
+class DefaultValue
+{
+};
 
 namespace internal
 {

--- a/orm_lib/inc/drogon/orm/DbTypes.h
+++ b/orm_lib/inc/drogon/orm/DbTypes.h
@@ -22,9 +22,8 @@ namespace orm
 
 class DefaultValue {};
 
-}  // namespace orm
-}  // namespace drogon
-
+namespace internal
+{
 enum FieldType
 {
     MySqlTiny,
@@ -35,5 +34,9 @@ enum FieldType
     MySqlString,
     DrogonDefaultValue,
 };
+
+}  // namespace internal
+}  // namespace orm
+}  // namespace drogon
 
 #endif  // DBTYPES_HPP

--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -289,7 +289,8 @@ class SqlBinder
               size_t sqlLength,
               DbClient &client,
               ClientType type)
-        : sqlViewPtr_(sql),
+        : sqlPtr_(std::make_shared<std::string>(sql, sqlLength)),
+          sqlViewPtr_(sql),
           sqlViewLength_(sqlLength),
           client_(client),
           type_(type)
@@ -468,7 +469,7 @@ class SqlBinder
     int getMysqlTypeBySize(size_t size);
     std::shared_ptr<std::string> sqlPtr_;
     const char *sqlViewPtr_;
-    const size_t sqlViewLength_;
+    size_t sqlViewLength_;
     DbClient &client_;
     size_t parametersNumber_{0};
     std::vector<const char *> parameters_;

--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -13,6 +13,7 @@
  */
 
 #pragma once
+#include <drogon/orm/DbTypes.h>
 #include <drogon/orm/Exception.h>
 #include <drogon/orm/Field.h>
 #include <drogon/orm/FunctionTraits.h>
@@ -432,6 +433,7 @@ class SqlBinder
     }
     self &operator<<(double f);
     self &operator<<(std::nullptr_t nullp);
+    self &operator<<(DefaultValue dv);
     self &operator<<(const Mode &mode)
     {
         mode_ = mode;

--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -289,8 +289,7 @@ class SqlBinder
               size_t sqlLength,
               DbClient &client,
               ClientType type)
-        : sqlPtr_(std::make_shared<std::string>(sql, sqlLength)),
-          sqlViewPtr_(sql),
+        : sqlViewPtr_(sql),
           sqlViewLength_(sqlLength),
           client_(client),
           type_(type)

--- a/orm_lib/src/SqlBinder.cc
+++ b/orm_lib/src/SqlBinder.cc
@@ -274,16 +274,14 @@ SqlBinder &SqlBinder::operator<<(DefaultValue dv)
 
         // decrement all other $n parameters by 1
         size_t i = parametersNumber_ + 2;
-        while ((sqlPtr_->find("$" + std::to_string(parametersNumber_ + i))) !=
-               std::string::npos)
+        while ((sqlPtr_->find("$" + std::to_string(i))) != std::string::npos)
         {
-            r = "\\$" + std::to_string(parametersNumber_ + i) + "\\b";
+            r = "\\$" + std::to_string(i) + "\\b";
             // use sed format to avoid $n regex group substitution,
             // and use ->data() to compile in C++14 mode
             *sqlPtr_ = std::regex_replace(sqlPtr_->data(),
                                           r,
-                                          "$" + std::to_string(
-                                                    parametersNumber_ + i - 1),
+                                          "$" + std::to_string(i - 1),
                                           std::regex_constants::format_sed);
             ++i;
         }

--- a/orm_lib/src/SqlBinder.cc
+++ b/orm_lib/src/SqlBinder.cc
@@ -268,7 +268,7 @@ SqlBinder &SqlBinder::operator<<(DefaultValue dv)
     lengths_.push_back(0);
     if (type_ == ClientType::PostgreSQL)
     {
-        formats_.push_back(0); // TODO
+        formats_.push_back(0);  // TODO
     }
     else if (type_ == ClientType::Mysql)
     {

--- a/orm_lib/src/mysql_impl/MysqlConnection.cc
+++ b/orm_lib/src/mysql_impl/MysqlConnection.cc
@@ -429,24 +429,24 @@ void MysqlConnection::execSqlInLoop(
                 pos = seekPos + 1;
                 switch (format[i])
                 {
-                    case MySqlTiny:
+                    case internal::MySqlTiny:
                         sql_.append(std::to_string(*((char *)parameters[i])));
                         break;
-                    case MySqlShort:
+                    case internal::MySqlShort:
                         sql_.append(std::to_string(*((short *)parameters[i])));
                         break;
-                    case MySqlLong:
+                    case internal::MySqlLong:
                         sql_.append(
                             std::to_string(*((int32_t *)parameters[i])));
                         break;
-                    case MySqlLongLong:
+                    case internal::MySqlLongLong:
                         sql_.append(
                             std::to_string(*((int64_t *)parameters[i])));
                         break;
-                    case MySqlNull:
+                    case internal::MySqlNull:
                         sql_.append("NULL");
                         break;
-                    case MySqlString:
+                    case internal::MySqlString:
                     {
                         sql_.append("'");
                         std::string to(length[i] * 2, '\0');
@@ -459,7 +459,7 @@ void MysqlConnection::execSqlInLoop(
                         sql_.append("'");
                     }
                     break;
-                    case DrogonDefaultValue:
+                    case internal::DrogonDefaultValue:
                         sql_.append("default");
                         break;
                     default:

--- a/orm_lib/src/mysql_impl/MysqlConnection.cc
+++ b/orm_lib/src/mysql_impl/MysqlConnection.cc
@@ -15,6 +15,7 @@
 #include "MysqlConnection.h"
 #include "MysqlResultImpl.h"
 #include <algorithm>
+#include <drogon/orm/DbTypes.h>
 #include <drogon/utils/Utilities.h>
 #include <drogon/utils/string_view.h>
 #include <errmsg.h>
@@ -428,24 +429,24 @@ void MysqlConnection::execSqlInLoop(
                 pos = seekPos + 1;
                 switch (format[i])
                 {
-                    case MYSQL_TYPE_TINY:
+                    case MySqlTiny:
                         sql_.append(std::to_string(*((char *)parameters[i])));
                         break;
-                    case MYSQL_TYPE_SHORT:
+                    case MySqlShort:
                         sql_.append(std::to_string(*((short *)parameters[i])));
                         break;
-                    case MYSQL_TYPE_LONG:
+                    case MySqlLong:
                         sql_.append(
                             std::to_string(*((int32_t *)parameters[i])));
                         break;
-                    case MYSQL_TYPE_LONGLONG:
+                    case MySqlLongLong:
                         sql_.append(
                             std::to_string(*((int64_t *)parameters[i])));
                         break;
-                    case MYSQL_TYPE_NULL:
+                    case MySqlNull:
                         sql_.append("NULL");
                         break;
-                    case MYSQL_TYPE_STRING:
+                    case MySqlString:
                     {
                         sql_.append("'");
                         std::string to(length[i] * 2, '\0');
@@ -458,6 +459,9 @@ void MysqlConnection::execSqlInLoop(
                         sql_.append("'");
                     }
                     break;
+                    case DrogonDefaultValue:
+                        sql_.append("default");
+                        break;
                     default:
                         break;
                 }

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -811,12 +811,14 @@ void doMysqlTest(const drogon::orm::DbClientPtr &clientPtr)
         };
     /// Test1:DbClient streaming-type interface
     /// 1.1 insert,non-blocking
-    *clientPtr << "insert into users (user_id,user_name,password,org_name) "
-                  "values(?,?,?,?)"
-               << "pg"
-               << "postgresql"
-               << "123"
-               << "default" >>
+    *clientPtr
+            << "insert into users (user_id,user_name,password,org_name,admin) "
+            "values(?,?,?,?,?)"
+            << "pg"
+            << "postgresql"
+            << "123"
+            << "default"
+            << drogon::orm::DefaultValue{} >>
         [](const Result &r) {
             testOutput(r.insertId() == 1,
                        "mysql - DbClient streaming-type interface(0)");

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -14,6 +14,7 @@
  */
 #include <drogon/config.h>
 #include <drogon/orm/DbClient.h>
+#include <drogon/orm/DbTypes.h>
 #include <trantor/utils/Logger.h>
 #include <chrono>
 #include <iostream>
@@ -125,12 +126,13 @@ void doPostgreTest(const drogon::orm::DbClientPtr &clientPtr)
                        "postgresql - DbClient streaming-type interface(0)");
         };
     /// 1.2 insert,blocking
-    *clientPtr << "insert into users (user_id,user_name,password,org_name) "
-                  "values($1,$2,$3,$4) returning *"
-               << "pg1"
-               << "postgresql1"
-               << "123"
-               << "default" << Mode::Blocking >>
+    *clientPtr
+            << "insert into users (user_id,user_name,password,org_name,admin) "
+               "values($1,$2,$3,$4,$5) returning *"
+            << "pg1"
+            << "postgresql1"
+            << "123"
+            << "default" << drogon::orm::DefaultValue{} << Mode::Blocking >>
         [](const Result &r) {
             // std::cout << "id=" << r[0]["id"].as<int64_t>() << std::endl;
             testOutput(r[0]["id"].as<int64_t>() == 2,

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -127,12 +127,11 @@ void doPostgreTest(const drogon::orm::DbClientPtr &clientPtr)
         };
     /// 1.2 insert,blocking
     *clientPtr
-            << "insert into users (user_id,user_name,password,org_name,admin) "
+            << "insert into users (user_id,user_name,admin,password,org_name) "
                "values($1,$2,$3,$4,$5) returning *"
             << "pg1"
-            << "postgresql1"
-            << "123"
-            << "default" << drogon::orm::DefaultValue{} << Mode::Blocking >>
+            << "postgresql1" << drogon::orm::DefaultValue{} << "123"
+            << "default" << Mode::Blocking >>
         [](const Result &r) {
             // std::cout << "id=" << r[0]["id"].as<int64_t>() << std::endl;
             testOutput(r[0]["id"].as<int64_t>() == 2,

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -813,12 +813,11 @@ void doMysqlTest(const drogon::orm::DbClientPtr &clientPtr)
     /// 1.1 insert,non-blocking
     *clientPtr
             << "insert into users (user_id,user_name,password,org_name,admin) "
-            "values(?,?,?,?,?)"
+               "values(?,?,?,?,?)"
             << "pg"
             << "postgresql"
             << "123"
-            << "default"
-            << drogon::orm::DefaultValue{} >>
+            << "default" << drogon::orm::DefaultValue{} >>
         [](const Result &r) {
             testOutput(r.insertId() == 1,
                        "mysql - DbClient streaming-type interface(0)");


### PR DESCRIPTION
This PR adds `drogon::orm::DefaultValue` type to be used with sqlbinder, for cases where there is a more complex default value defined in database for ex. `current_time() + 30'.

It works by using `insert .... values (..., default, ...);` syntax. PostgreSql and MariaDB both support it, but Sqlite3 does not. I, however haven't found a way to accomplish the same with PostgreSql without moving to manual sql statment creation, away from `PQsendPrepare` and `PQsendQueryPrepared`, relevant [documentation](https://www.postgresql.org/docs/13/libpq-async.html). 

Doing so has possible implications for both performance and correctness. We should discuss if there is enough motivation to do so.