### PR TITLE
Fix stack use after scope error in client_example

### DIFF
--- a/examples/client_example/main.cc
+++ b/examples/client_example/main.cc
@@ -20,8 +20,7 @@ int main()
         for (int i = 0; i < 10; ++i)
         {
             client->sendRequest(
-                req,
-                [](ReqResult result, const HttpResponsePtr &response) {
+                req, [](ReqResult result, const HttpResponsePtr &response) {
                     std::cout << "receive response!" << std::endl;
                     // auto headers=response.
                     ++nth_resp;

--- a/examples/client_example/main.cc
+++ b/examples/client_example/main.cc
@@ -4,11 +4,12 @@
 
 using namespace drogon;
 
+int nth_resp = 0;
+
 int main()
 {
     trantor::Logger::setLogLevel(trantor::Logger::kTrace);
     {
-        int count = 0;
         auto client = HttpClient::newHttpClient("http://www.baidu.com");
         auto req = HttpRequest::newHttpRequest();
         req->setMethod(drogon::Get);
@@ -20,10 +21,10 @@ int main()
         {
             client->sendRequest(
                 req,
-                [&count](ReqResult result, const HttpResponsePtr &response) {
+                [](ReqResult result, const HttpResponsePtr &response) {
                     std::cout << "receive response!" << std::endl;
                     // auto headers=response.
-                    ++count;
+                    ++nth_resp;
                     std::cout << response->getBody() << std::endl;
                     auto cookies = response->cookies();
                     for (auto const &cookie : cookies)
@@ -33,7 +34,7 @@ int main()
                                   << ":domain=" << cookie.second.domain()
                                   << std::endl;
                     }
-                    std::cout << "count=" << count << std::endl;
+                    std::cout << "count=" << nth_resp << std::endl;
                 });
         }
     }


### PR DESCRIPTION
A quick fix for an use after scope bug in `client_example`.

**How to reprduce**

Build drogon in debug mode with address sanitizer. Run `examples/client`. Then this shows up

![image](https://user-images.githubusercontent.com/8792393/107133633-5a9ee000-6925-11eb-86ab-d49ffbe149ae.png)



