### PR TITLE
Fix DrClassMap leak

### DIFF
--- a/drogon_ctl/cmd.cc
+++ b/drogon_ctl/cmd.cc
@@ -33,11 +33,10 @@ void exeCommand(std::vector<std::string> &parameters)
     parameters.erase(parameters.begin());
 
     // new command handler to do cmd
-    auto obj = std::shared_ptr<DrObjectBase>(
-        drogon::DrClassMap::newObject(handlerName));
+    auto obj = drogon::DrClassMap::newObject(handlerName);
     if (obj)
     {
-        auto ctl = std::dynamic_pointer_cast<CommandHandler>(obj);
+        auto ctl = dynamic_cast<CommandHandler *>(obj);
         if (ctl)
         {
             ctl->handleCommand(parameters);

--- a/lib/inc/drogon/DrClassMap.h
+++ b/lib/inc/drogon/DrClassMap.h
@@ -117,7 +117,11 @@ class DrClassMap
         LOG_ERROR << "Demangle error!";
         return "";
 #else
-        return mangled_name;
+        auto pos = strstr(mangled_name, " ");
+        if (pos == nullptr)
+            return std::string{mangled_name};
+        else
+            return std::string{pos + 1};
 #endif
     }
 

--- a/lib/inc/drogon/DrObject.h
+++ b/lib/inc/drogon/DrObject.h
@@ -23,6 +23,7 @@
 #pragma warning(disable : 4250)
 #endif
 
+
 namespace drogon
 {
 /**
@@ -79,9 +80,8 @@ class DrObject : public virtual DrObjectBase
 
   protected:
     // protect constructor to make this class only inheritable
-    DrObject()
-    {
-    }
+    DrObject() = default;
+    virtual ~DrObject() = default;
 
   private:
     class DrAllocator
@@ -103,7 +103,7 @@ class DrObject : public virtual DrObjectBase
         registerClass()
         {
             DrClassMap::registerClass(className(),
-                                      []() -> DrObjectBase * { return new T; });
+                                      []() { return std::make_unique<T>(); });
         }
         template <typename D>
         typename std::enable_if<!std::is_default_constructible<D>::value,

--- a/lib/inc/drogon/DrObject.h
+++ b/lib/inc/drogon/DrObject.h
@@ -23,7 +23,6 @@
 #pragma warning(disable : 4250)
 #endif
 
-
 namespace drogon
 {
 /**

--- a/lib/src/DrClassMap.cc
+++ b/lib/src/DrClassMap.cc
@@ -91,7 +91,8 @@ std::unordered_map<std::string, DrAllocFunc> &DrClassMap::getMap()
     return map;
 }
 
-std::shared_ptr<DrObjectBase> DrClassMap::createUniqueObject(const std::string& className)
+std::shared_ptr<DrObjectBase> DrClassMap::createUniqueObject(
+    const std::string &className)
 {
     auto iter = getMap().find(className);
     if (iter != getMap().end())


### PR DESCRIPTION
Backported from my other PR. Before this PR, DrClassMap does not call the constructor of the objects allocated. This may be fine if the objects only allocates memory. But may cause files kept locked, exit message not sent, etc... Now it's fixed.