### PR TITLE
fix DrObject test memory leak

### DIFF
--- a/unittest/DrObjectUnittest.cpp
+++ b/unittest/DrObjectUnittest.cpp
@@ -15,7 +15,8 @@ class TestB : public DrObject<TestB>
 }  // namespace test
 TEST(DrObjectTest, creationTest)
 {
-    auto obj = DrClassMap::newObject("TestA");
+    using PtrType = std::shared_ptr<DrObjectBase>;
+    auto obj = PtrType(DrClassMap::newObject("TestA"));
     EXPECT_NE(obj, nullptr);
 
     auto objPtr = DrClassMap::getSingleInstance("TestA");
@@ -28,7 +29,8 @@ TEST(DrObjectTest, creationTest)
 
 TEST(DrObjectTest, namespaceTest)
 {
-    auto obj = DrClassMap::newObject("test::TestB");
+    using PtrType = std::shared_ptr<DrObjectBase>;
+    auto obj = PtrType(DrClassMap::newObject("test::TestB"));
     EXPECT_NE(obj, nullptr);
 
     auto objPtr = DrClassMap::getSingleInstance("test::TestB");


### PR DESCRIPTION
Fixes a memory leak in DrObject unit test. The bug is visable when drogon is built with address sanitizer enabled.

Before:
![image](https://user-images.githubusercontent.com/8792393/108068235-c78c4580-709c-11eb-8d3f-436bf00b9522.png)
