### PR TITLE
Fix drogon::Task<> not destructing internal object

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -23,7 +23,6 @@
 #include <atomic>
 #include <future>
 #include <cassert>
-#include <iostream>
 
 namespace drogon
 {
@@ -107,7 +106,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task && other)
+    Task(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -118,7 +117,7 @@ struct [[nodiscard]] Task
             coro_.destroy();
     }
     Task &operator=(const Task &) = delete;
-    Task &operator=(Task && other)
+    Task &operator=(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -155,7 +154,6 @@ struct [[nodiscard]] Task
             if (exception_ != nullptr)
                 std::rethrow_exception(exception_);
             assert(value.has_value() == true);
-            std::cout << "rvalue" << std::endl;
             return std::move(value.value());
         }
 
@@ -266,7 +264,7 @@ struct [[nodiscard]] Task<void>
             coro_.destroy();
     }
     Task &operator=(const Task &) = delete;
-    Task &operator=(Task && other)
+    Task &operator=(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -13,6 +13,8 @@
  */
 #pragma once
 
+#include <drogon/utils/optional.h>
+#include <trantor/net/EventLoop.h>
 #include <algorithm>
 #include <coroutine>
 #include <exception>
@@ -21,14 +23,10 @@
 #include <atomic>
 #include <future>
 #include <cassert>
-#include <optional>
 #include <iostream>
-#include <trantor/net/EventLoop.h>
 
 namespace drogon
 {
-template <typename T>
-using optional = std::optional<T>;
 namespace internal
 {
 template <typename T>

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -107,7 +107,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -118,7 +118,7 @@ struct [[nodiscard]] Task
             coro_.destroy();
     }
     Task &operator=(const Task &) = delete;
-    Task &operator=(Task &&other)
+    Task &operator=(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -106,7 +106,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -255,7 +255,7 @@ struct [[nodiscard]] Task<void>
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -266,7 +266,7 @@ struct [[nodiscard]] Task<void>
             coro_.destroy();
     }
     Task &operator=(const Task &) = delete;
-    Task &operator=(Task &&other)
+    Task &operator=(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;

--- a/lib/tests/CoroutineTest.cc
+++ b/lib/tests/CoroutineTest.cc
@@ -1,9 +1,35 @@
 #include <drogon/utils/coroutine.h>
 #include <exception>
+#include <memory>
 #include <type_traits>
 #include <iostream>
+#include <cppcoro/task.hpp>
 
 using namespace drogon;
+
+namespace drogon::internal
+{
+struct SomeStruct
+{
+    ~SomeStruct()
+    {
+        beenDestructed = true;
+    }
+    static bool beenDestructed;
+};
+
+bool SomeStruct::beenDestructed = false;
+
+struct StructAwaiter : public CallbackAwaiter<std::shared_ptr<SomeStruct>>
+{
+    void await_suspend(std::coroutine_handle<> handle)
+    {
+        setValue(std::make_shared<SomeStruct>());
+        handle.resume();
+    }
+};
+
+}  // namespace drogon::internal
 
 int main()
 {
@@ -39,7 +65,7 @@ int main()
 
         try
         {
-            f();
+            co_await f();
             std::cerr << "Exception should have been thrown\n";
             exit(1);
         }
@@ -59,6 +85,25 @@ int main()
         co_return;
     };
     sync_wait(throw_in_task());
+
+    // Test coroutine destruction
+    auto destruct = []() -> Task<> {
+        auto awaitStruct = []() -> Task<std::shared_ptr<internal::SomeStruct>> {
+            co_return co_await internal::StructAwaiter();
+        };
+
+        auto awaitNothing = [awaitStruct]() -> Task<> {
+            co_await awaitStruct();
+        };
+
+        co_await awaitNothing();
+    };
+    sync_wait(destruct());
+    if (internal::SomeStruct::beenDestructed == false)
+    {
+        std::cerr << "Coroutine didn't destruct allocated object.\n";
+        exit(1);
+    }
 
     std::cout << "Done testing coroutines. No error." << std::endl;
 }

--- a/lib/tests/CoroutineTest.cc
+++ b/lib/tests/CoroutineTest.cc
@@ -3,7 +3,6 @@
 #include <memory>
 #include <type_traits>
 #include <iostream>
-#include <cppcoro/task.hpp>
 
 using namespace drogon;
 


### PR DESCRIPTION
This PR fix #728 . But the test shows `Task` is leaking memory in the new test. Yet `cppcoro` experiences almost the same issue. I'm wondering  if this is a compiler bug,

```
Indirect leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0xffff854111e4 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0xaaaad3429bd4 in operator() /home/marty/Documents/drogon/lib/tests/CoroutineTest.cc:93
    #2 0xaaaad3429bd4 in main::{lambda()#4}::operator()() const::{lambda()#2}::operator()() const [clone .actor] /home/marty/Documents/drogon/lib/tests/CoroutineTest.cc:96
    #3 0xaaaad342ab8c in main::{lambda()#4}::operator()() const [clone .actor] /home/marty/Documents/drogon/lib/tests/CoroutineTest.cc:90
    #4 0xaaaad342d3e4 in drogon::sync_wait<drogon::Task<void> >(drogon::Task<void>&&)::{lambda()#1}::operator()() const [clone .actor] /home/marty/Documents/drogon/lib/inc/drogon/utils/coroutine.h:505
    #5 0xaaaad342fdc4 in drogon::sync_wait<drogon::Task<void> >(drogon::Task<void>&&)::{lambda()#1}::operator()() const /home/marty/Documents/drogon/lib/inc/drogon/utils/coroutine.h:505
    #6 0xaaaad342fdc4 in auto drogon::sync_wait<drogon::Task<void> >(drogon::Task<void>&&) /home/marty/Documents/drogon/lib/inc/drogon/utils/coroutine.h:517
    #7 0xaaaad342b6b4 in main /home/marty/Documents/drogon/lib/tests/CoroutineTest.cc:101
    #8 0xffff84904534 in __libc_start_main (/usr/lib/libc.so.6+0x24534)
    #9 0xaaaad3426dd0  (/home/marty/Documents/drogon/build/lib/tests/coroutine_test+0x3dd0)

Indirect leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0xffff854111e4 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0xaaaad342a748 in operator() /home/marty/Documents/drogon/lib/tests/CoroutineTest.cc:97
    #2 0xaaaad342a748 in main::{lambda()#4}::operator()() const [clone .actor] /home/marty/Documents/drogon/lib/tests/CoroutineTest.cc:99
    #3 0xaaaad342d3e4 in drogon::sync_wait<drogon::Task<void> >(drogon::Task<void>&&)::{lambda()#1}::operator()() const [clone .actor] /home/marty/Documents/drogon/lib/inc/drogon/utils/coroutine.h:505
    #4 0xaaaad342fdc4 in drogon::sync_wait<drogon::Task<void> >(drogon::Task<void>&&)::{lambda()#1}::operator()() const /home/marty/Documents/drogon/lib/inc/drogon/utils/coroutine.h:505
    #5 0xaaaad342fdc4 in auto drogon::sync_wait<drogon::Task<void> >(drogon::Task<void>&&) /home/marty/Documents/drogon/lib/inc/drogon/utils/coroutine.h:517
    #6 0xaaaad342b6b4 in main /home/marty/Documents/drogon/lib/tests/CoroutineTest.cc:101
    #7 0xffff84904534 in __libc_start_main (/usr/lib/libc.so.6+0x24534)
    #8 0xaaaad3426dd0  (/home/marty/Documents/drogon/build/lib/tests/coroutine_test+0x3dd0)
```