### PR TITLE
return awaiter from coroutine instead of resumable

### DIFF
--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -150,7 +150,7 @@ class HttpClient : public trantor::NonCopyable
      * timeout, the `ReqResult::Timeout` and an empty response is returned. The
      * zero value by default disables the timeout.
      *
-     * @return task<HttpResponsePtr>
+     * @return internal::HttpRespAwaiter
      */
     internal::HttpRespAwaiter sendRequestCoro(HttpRequestPtr req,
                                               double timeout = 0)

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -152,12 +152,10 @@ class HttpClient : public trantor::NonCopyable
      *
      * @return task<HttpResponsePtr>
      */
-    Task<HttpResponsePtr> sendRequestCoro(HttpRequestPtr req,
-                                          double timeout = 0)
+    internal::HttpRespAwaiter sendRequestCoro(HttpRequestPtr req,
+                                              double timeout = 0)
     {
-        co_return co_await internal::HttpRespAwaiter(this,
-                                                     std::move(req),
-                                                     timeout);
+        return internal::HttpRespAwaiter(this, std::move(req), timeout);
     }
 #endif
 

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -142,15 +142,15 @@ class HttpClient : public trantor::NonCopyable
 
 #ifdef __cpp_impl_coroutine
     /**
-     * @brief Send a request via coroutines to the server and return the
-     * response.
+     * @brief Send a request via coroutines to the server and return an
+     * awaiter. Whom could be `co_await`-ed to retrieve the response
      *
      * @param req
      * @param timeout In seconds. If the response is not received within the
-     * timeout, the `ReqResult::Timeout` and an empty response is returned. The
-     * zero value by default disables the timeout.
+     * timeout, A `std::runtime_error` with the message "Timeout" is thrown.
+     * The zero value by default disables the timeout.
      *
-     * @return internal::HttpRespAwaiter
+     * @return internal::HttpRespAwaiter. Await on it to get the response
      */
     internal::HttpRespAwaiter sendRequestCoro(HttpRequestPtr req,
                                               double timeout = 0)
@@ -269,6 +269,8 @@ class HttpClient : public trantor::NonCopyable
 inline void internal::HttpRespAwaiter::await_suspend(
     std::coroutine_handle<> handle)
 {
+    assert(client_ != nullptr);
+    assert(req_ != nullptr);
     client_->sendRequest(
         req_,
         [handle = std::move(handle), this](ReqResult result,

--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -143,7 +143,8 @@ class HttpClient : public trantor::NonCopyable
 #ifdef __cpp_impl_coroutine
     /**
      * @brief Send a request via coroutines to the server and return an
-     * awaiter. Whom could be `co_await`-ed to retrieve the response
+     * awaiter what could be `co_await`-ed to retrieve the response
+     * (HttpResponsePtr)
      *
      * @param req
      * @param timeout In seconds. If the response is not received within the

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -106,7 +106,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task && other)
+    Task(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -253,7 +253,7 @@ struct [[nodiscard]] Task<void>
     {
     }
     Task(const Task &) = delete;
-    Task(Task && other)
+    Task(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -424,7 +424,7 @@ struct CallbackAwaiter
         return false;
     }
 
-    const T &await_resume() noexcept(false)
+    const T &await_resume() const noexcept(false)
     {
         // await_resume() should always be called after co_await
         // (await_suspend()) is called. Therefor the value should always be set
@@ -595,18 +595,19 @@ struct TimerAwaiter : CallbackAwaiter<void>
 };
 }  // namespace internal
 
-inline Task<void> sleepCoro(
+inline internal::TimerAwaiter sleepCoro(
     trantor::EventLoop *loop,
     const std::chrono::duration<long double> &delay) noexcept
 {
     assert(loop);
-    co_return co_await internal::TimerAwaiter(loop, delay);
+    return internal::TimerAwaiter(loop, delay);
 }
 
-inline Task<void> sleepCoro(trantor::EventLoop *loop, double delay) noexcept
+inline internal::TimerAwaiter sleepCoro(trantor::EventLoop *loop,
+                                        double delay) noexcept
 {
     assert(loop);
-    co_return co_await internal::TimerAwaiter(loop, delay);
+    return internal::TimerAwaiter(loop, delay);
 }
 
 }  // namespace drogon

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -106,7 +106,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -253,7 +253,7 @@ struct [[nodiscard]] Task<void>
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;

--- a/orm_lib/inc/drogon/orm/CoroMapper.h
+++ b/orm_lib/inc/drogon/orm/CoroMapper.h
@@ -64,7 +64,7 @@ class CoroMapper : public Mapper<T>
     {
     }
     using TraitsPKType = typename Mapper<T>::TraitsPKType;
-    inline const Task<T> findByPrimaryKey(const TraitsPKType &key)
+    inline internal::MapperAwaiter<T> findByPrimaryKey(const TraitsPKType &key)
     {
         if constexpr (!std::is_same<typename T::PrimaryKeyType, void>::value)
         {
@@ -111,7 +111,7 @@ class CoroMapper : public Mapper<T>
                 binder >> std::move(errCallback);
                 binder.exec();
             };
-            co_return co_await internal::MapperAwaiter<T>(std::move(lb));
+            return internal::MapperAwaiter<T>(std::move(lb));
         }
         else
         {
@@ -119,11 +119,12 @@ class CoroMapper : public Mapper<T>
             abort();
         }
     }
-    inline const Task<std::vector<T>> findAll()
+    inline internal::MapperAwaiter<std::vector<T>> findAll()
     {
-        co_return co_await findBy(Criteria());
+        return findBy(Criteria());
     }
-    inline const Task<size_t> count(const Criteria &criteria = Criteria())
+    inline internal::MapperAwaiter<size_t> count(
+        const Criteria &criteria = Criteria())
     {
         auto lb =
             [this, criteria](
@@ -147,9 +148,9 @@ class CoroMapper : public Mapper<T>
                 };
                 binder >> std::move(errCallback);
             };
-        co_return co_await internal::MapperAwaiter<size_t>(std::move(lb));
+        return internal::MapperAwaiter<size_t>(std::move(lb));
     }
-    inline const Task<T> findOne(const Criteria &criteria)
+    inline internal::MapperAwaiter<T> findOne(const Criteria &criteria)
     {
         auto lb =
             [this, criteria](
@@ -208,9 +209,10 @@ class CoroMapper : public Mapper<T>
                 };
                 binder >> std::move(errCallback);
             };
-        co_return co_await internal::MapperAwaiter<T>(std::move(lb));
+        return internal::MapperAwaiter<T>(std::move(lb));
     }
-    inline const Task<std::vector<T>> findBy(const Criteria &criteria)
+    inline internal::MapperAwaiter<std::vector<T>> findBy(
+        const Criteria &criteria)
     {
         auto lb =
             [this, criteria](
@@ -260,10 +262,9 @@ class CoroMapper : public Mapper<T>
                 };
                 binder >> std::move(errCallback);
             };
-        co_return co_await internal::MapperAwaiter<std::vector<T>>(
-            std::move(lb));
+        return internal::MapperAwaiter<std::vector<T>>(std::move(lb));
     }
-    inline const Task<T> insert(const T &obj)
+    inline internal::MapperAwaiter<T> insert(const T &obj)
     {
         auto lb =
             [this, obj](
@@ -317,9 +318,9 @@ class CoroMapper : public Mapper<T>
                 };
                 binder >> std::move(errCallback);
             };
-        co_return co_await internal::MapperAwaiter<T>(std::move(lb));
+        return internal::MapperAwaiter<T>(std::move(lb));
     }
-    inline const Task<size_t> update(const T &obj)
+    inline internal::MapperAwaiter<size_t> update(const T &obj)
     {
         auto lb =
             [this, obj](
@@ -350,9 +351,9 @@ class CoroMapper : public Mapper<T>
                 };
                 binder >> std::move(errCallback);
             };
-        co_return co_await internal::MapperAwaiter<size_t>(std::move(lb));
+        return internal::MapperAwaiter<size_t>(std::move(lb));
     }
-    inline const Task<size_t> deleteOne(const T &obj)
+    inline internal::MapperAwaiter<size_t> deleteOne(const T &obj)
     {
         auto lb =
             [this, obj](
@@ -376,9 +377,9 @@ class CoroMapper : public Mapper<T>
                 };
                 binder >> std::move(errCallback);
             };
-        co_return co_await internal::MapperAwaiter<size_t>(std::move(lb));
+        return internal::MapperAwaiter<size_t>(std::move(lb));
     }
-    inline const Task<size_t> deleteBy(const Criteria &criteria)
+    inline internal::MapperAwaiter<size_t> deleteBy(const Criteria &criteria)
     {
         auto lb =
             [this, criteria](
@@ -408,9 +409,10 @@ class CoroMapper : public Mapper<T>
                 };
                 binder >> std::move(errCallback);
             };
-        co_return co_await internal::MapperAwaiter<size_t>(std::move(lb));
+        return internal::MapperAwaiter<size_t>(std::move(lb));
     }
-    inline const Task<size_t> deleteByPrimaryKey(const TraitsPKType &key)
+    inline internal::MapperAwaiter<size_t> deleteByPrimaryKey(
+        const TraitsPKType &key)
     {
         static_assert(!std::is_same<typename T::PrimaryKeyType, void>::value,
                       "No primary key in the table!");
@@ -430,7 +432,7 @@ class CoroMapper : public Mapper<T>
             };
             binder >> std::move(errCallback);
         };
-        co_return co_await internal::MapperAwaiter<size_t>(std::move(lb));
+        return internal::MapperAwaiter<size_t>(std::move(lb));
     }
 };
 }  // namespace orm

--- a/orm_lib/inc/drogon/orm/DbClient.h
+++ b/orm_lib/inc/drogon/orm/DbClient.h
@@ -152,7 +152,7 @@ class DbClient : public trantor::NonCopyable
     void execSqlAsync(const std::string &sql,
                       FUNCTION1 &&rCallback,
                       FUNCTION2 &&exceptCallback,
-                      Arguments &&...args) noexcept
+                      Arguments &&... args) noexcept
     {
         auto binder = *this << sql;
         (void)std::initializer_list<int>{
@@ -164,7 +164,7 @@ class DbClient : public trantor::NonCopyable
     /// Async and nonblocking method
     template <typename... Arguments>
     std::future<Result> execSqlAsyncFuture(const std::string &sql,
-                                           Arguments &&...args) noexcept
+                                           Arguments &&... args) noexcept
     {
         auto binder = *this << sql;
         (void)std::initializer_list<int>{
@@ -181,7 +181,7 @@ class DbClient : public trantor::NonCopyable
     // Sync and blocking method
     template <typename... Arguments>
     const Result execSqlSync(const std::string &sql,
-                             Arguments &&...args) noexcept(false)
+                             Arguments &&... args) noexcept(false)
     {
         Result r(nullptr);
         {

--- a/orm_lib/inc/drogon/orm/DbClient.h
+++ b/orm_lib/inc/drogon/orm/DbClient.h
@@ -152,7 +152,7 @@ class DbClient : public trantor::NonCopyable
     void execSqlAsync(const std::string &sql,
                       FUNCTION1 &&rCallback,
                       FUNCTION2 &&exceptCallback,
-                      Arguments &&... args) noexcept
+                      Arguments &&...args) noexcept
     {
         auto binder = *this << sql;
         (void)std::initializer_list<int>{
@@ -164,7 +164,7 @@ class DbClient : public trantor::NonCopyable
     /// Async and nonblocking method
     template <typename... Arguments>
     std::future<Result> execSqlAsyncFuture(const std::string &sql,
-                                           Arguments &&... args) noexcept
+                                           Arguments &&...args) noexcept
     {
         auto binder = *this << sql;
         (void)std::initializer_list<int>{
@@ -181,7 +181,7 @@ class DbClient : public trantor::NonCopyable
     // Sync and blocking method
     template <typename... Arguments>
     const Result execSqlSync(const std::string &sql,
-                             Arguments &&... args) noexcept(false)
+                             Arguments &&...args) noexcept(false)
     {
         Result r(nullptr);
         {
@@ -199,13 +199,13 @@ class DbClient : public trantor::NonCopyable
 
 #ifdef __cpp_impl_coroutine
     template <typename... Arguments>
-    const Task<Result> execSqlCoro(const std::string sql,
-                                   Arguments... args) noexcept
+    internal::SqlAwaiter execSqlCoro(const std::string sql,
+                                     Arguments... args) noexcept
     {
         auto binder = *this << sql;
         (void)std::initializer_list<int>{
             (binder << std::forward<Arguments>(args), 0)...};
-        co_return co_await internal::SqlAwaiter(std::move(binder));
+        return internal::SqlAwaiter(std::move(binder));
     }
 #endif
 
@@ -244,9 +244,9 @@ class DbClient : public trantor::NonCopyable
             &callback) = 0;
 
 #ifdef __cpp_impl_coroutine
-    Task<std::shared_ptr<Transaction>> newTransactionCoro()
+    orm::internal::TrasactionAwaiter newTransactionCoro()
     {
-        co_return co_await orm::internal::TrasactionAwaiter(this);
+        return orm::internal::TrasactionAwaiter(this);
     }
 #endif
 


### PR DESCRIPTION
Returns _awaitable_ instead of _resumable_ in coroutine enabled functions. This should reduce 1 dynamic allocation per coroutine execution.