### PR TITLE
Fix compile warnings in SQL client

### DIFF
--- a/orm_lib/inc/drogon/orm/SqlBinder.h
+++ b/orm_lib/inc/drogon/orm/SqlBinder.h
@@ -369,24 +369,38 @@ class SqlBinder : public trantor::NonCopyable
         if (type_ == ClientType::PostgreSQL)
         {
 #if __cplusplus >= 201703L || (defined _MSC_VER && _MSC_VER > 1900)
-#define DROGON_CONSTEXPR constexpr
-#else
-#define DROGON_CONSTEXPR
-#endif
             const size_t size = sizeof(T);
-            if DROGON_CONSTEXPR (size == 2)
+            if constexpr (size == 2)
             {
                 *std::static_pointer_cast<uint16_t>(obj) = htons(parameter);
             }
-            else if DROGON_CONSTEXPR (size == 4)
+            else if constexpr (size == 4)
             {
                 *std::static_pointer_cast<uint32_t>(obj) = htonl(parameter);
             }
-            else if DROGON_CONSTEXPR (size == 8)
+            else if constexpr (size == 8)
             {
                 *std::static_pointer_cast<uint64_t>(obj) = htonll(parameter);
             }
-#undef DROGON_CONSTEXPR
+#else
+            switch (sizeof(T))
+            {
+                case 2:
+                    *std::static_pointer_cast<uint16_t>(obj) = htons(parameter);
+                    break;
+                case 4:
+                    *std::static_pointer_cast<uint32_t>(obj) = htonl(parameter);
+                    break;
+                case 8:
+                    *std::static_pointer_cast<uint64_t>(obj) =
+                        htonll(parameter);
+                    break;
+                case 1:
+                default:
+
+                    break;
+            }
+#endif
             objs_.push_back(obj);
             parameters_.push_back((char *)obj.get());
             lengths_.push_back(sizeof(T));


### PR DESCRIPTION
`if constexpr` is available since C++ 17. ~~Idk whether the `define` then `undef` code looks great.~~
The warning:
```
E:\REDACTED\models\Unit.cpp(69): note: 查看对正在编译的函数 模板 实例化“const drogon::orm::Result drogon::orm::DbClient::execSqlSync<uint64_t&>(const std::string &,uint64_t &) noexcept(false)”的引用
E:\REDACTED\cmake-build-release\vcpkg_installed\x64-windows-static\include\drogon/orm/SqlBinder.h(352): warning C4244: “参数”: 从“uint64_t”转换到“u_long”，可能丢失数据
E:\REDACTED\cmake-build-release\vcpkg_installed\x64-windows-static\include\drogon/orm/SqlBinder.h(349): warning C4244: “参数”: 从“uint64_t”转换到“u_short”，可能丢失数据
E:\REDACTED\cmake-build-release\vcpkg_installed\x64-windows-static\include\drogon/orm/DbClient.h(138): note: 查看对正在编译的函数 模板 实例化“drogon::orm::internal::SqlBinder &drogon::orm::internal::SqlBinder::operator <<<uint64_t&>(T)”的引用
        with
        [
            T=uint64_t &
        ]
```