### PR TITLE
Fix build.sh missing nproc error in build for macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ case $(uname) in
     nproc=$(sysctl -n hw.ncpu)
     ;;
  Darwin)
-    nproc=$(sysctl -n hw.logicalcpu) # sysctl -n hw.logicalcpu is the equivalent to nproc on macOS.
+    nproc=$(sysctl -n hw.ncpu) # sysctl -n hw.ncpu is the equivalent to nproc on macOS.
     ;;
  *)
     nproc=$(nproc)

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ case $(uname) in
     nproc=$(sysctl -n hw.ncpu)
     ;;
  Darwin)
-    nproc=$(sysctl -n hw.logicalcpu) # sysctl -n hw.physicalcpu is the equivalent to nproc on macOS.
+    nproc=$(sysctl -n hw.logicalcpu) # sysctl -n hw.logicalcpu is the equivalent to nproc on macOS.
     ;;
  *)
     nproc=$(nproc)

--- a/build.sh
+++ b/build.sh
@@ -58,11 +58,17 @@ make_flags=''
 cmake_gen=''
 parallel=1
 
-if [ $(uname) = 'FreeBSD' ]; then
-  nproc=$(sysctl -n hw.ncpu)
-else
-  nproc=$(nproc)
-fi
+case $(uname) in
+ FreeBSD)
+    nproc=$(sysctl -n hw.ncpu)
+    ;;
+ Darwin)
+    nproc=$(sysctl -n hw.logicalcpu) # sysctl -n hw.physicalcpu is the equivalent to nproc on macOS.
+    ;;
+ *)
+    nproc=$(nproc)
+    ;;
+esac
 
 # simulate ninja's parallelism
 case nproc in


### PR DESCRIPTION
On MacOS there is no nproc. Error:

```
./build.sh: linia 64: nproc: nie znaleziono polecenia
```

Additional: i changed if statmanent to case

discussion: https://github.com/an-tao/drogon/pull/750