### PR TITLE
remove 'TODO: SSL validation' comment from HttpClient

### DIFF
--- a/lib/inc/drogon/HttpClient.h
+++ b/lib/inc/drogon/HttpClient.h
@@ -66,7 +66,6 @@ struct HttpRespAwaiter : public CallbackAwaiter<HttpResponsePtr>
  * implementing the class, the shared_ptr is retained in the framework until all
  * response callbacks are invoked without fear of accidental deconstruction.
  *
- * TODO:SSL server verification
  */
 class HttpClient : public trantor::NonCopyable
 {


### PR DESCRIPTION
SSL validation was introduced in #726. This comment is obsolete.