### PR TITLE
Add exception to handle http body parsing errors

### DIFF
--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -29,7 +29,6 @@
 
 namespace drogon
 {
-
 class BodyParsingException : public std::runtime_error
 {
   public:

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -39,7 +39,7 @@ class BodyParsingException : public std::runtime_error
     {
     }
 
-    [[nodiscard]] HttpStatusCode getStatus() const
+    HttpStatusCode getStatus() const
     {
         return mStatus;
     }

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -33,8 +33,9 @@ namespace drogon
 class BodyParsingException : public std::runtime_error
 {
   public:
-    explicit BodyParsingException(const std::string &msg = "Error converting body",
-                                    HttpStatusCode status = k400BadRequest)
+    explicit BodyParsingException(
+        const std::string &msg = "Error converting body",
+        HttpStatusCode status = k400BadRequest)
         : std::runtime_error(msg), mStatus(status)
     {
     }


### PR DESCRIPTION
When using the `T fromRequest(const HttpRequest &req)` specialization, if the body is ill-formed, the user may want to return a response with the detailed error.

This PR adds this behaviour, e.g:

```
template <>
inline myapp::User fromRequest(const HttpRequest &req)
{
    auto json = req.getJsonObject();
    myapp::User user;
    if(json)
    {
        user.userName = (*json)["name"].asString();
        user.email = (*json)["email"].asString();
        user.address = (*json)["address"].asString();
    } 
    else
    {
        throw BodyParsingException("No json object found in request");
    }
    return user;
}
```

I don't know where to put `BodyParsingException` so I let it in HttpBinder. If you want it elsewhere, I can move it.