### PR TITLE
Use canonical way of calling max() function on Windows

### DIFF
--- a/lib/inc/drogon/IOThreadStorage.h
+++ b/lib/inc/drogon/IOThreadStorage.h
@@ -69,12 +69,8 @@ class IOThreadStorage : public trantor::NonCopyable
         static_assert(std::is_constructible<C, Args &&...>::value,
                       "Unable to construct storage with given signature");
         size_t numThreads = app().getThreadNum();
-#ifdef _WIN32
-        assert(numThreads > 0 && numThreads != size_t(-1));
-#else
         assert(numThreads > 0 &&
-               numThreads != std::numeric_limits<size_t>::max());
-#endif
+               numThreads != (std::numeric_limits<size_t>::max)());
         // set the size to numThreads+1 to enable access to this in the main
         // thread.
         storage_.reserve(numThreads + 1);

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -486,11 +486,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         {
             return loop->index();
         }
-#ifdef _WIN32
-        return size_t(-1);
-#else
-        return std::numeric_limits<size_t>::max();
-#endif
+        return (std::numeric_limits<size_t>::max)();
     }
 
     bool areAllDbClientsAvailable() const noexcept override;


### PR DESCRIPTION
Pullrequest #335 introduced _WIN32 preprocessor checks to avoid calling `std::numeric_limits<size_t>::max()`.
It is better to use the canonical way of avoiding the well-known min/max macro hell on Windows, just like in various other code places.