### PR TITLE
Added newFileResponse Support for buffers in memory

### DIFF
--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -353,6 +353,20 @@ class HttpResponse
         const std::string &attachmentFileName = "",
         ContentType type = CT_NONE);
 
+    /// Create a response that returns a file to the client from buffer in memory/stack
+    /**
+     * @param pBuffer uint 8 bit flat buffer for image
+     * @param attachmentFileName if the parameter is not empty, the browser
+     * @param type if the parameter is CT_NONE, the content type is set by
+     * @param bufferLength length of expected buffer
+     * drogon based on the file extension.
+     */
+    static HttpResponsePtr newFileResponse(
+        const unsigned char *pBuffer,
+        size_t bufferLength,
+        const std::string &attachmentFileName = "",
+        ContentType type = CT_NONE);
+
     /**
      * @brief Create a custom HTTP response object. For using this template,
      * users must specialize the toResponse template.

--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -353,7 +353,8 @@ class HttpResponse
         const std::string &attachmentFileName = "",
         ContentType type = CT_NONE);
 
-    /// Create a response that returns a file to the client from buffer in memory/stack
+    /// Create a response that returns a file to the client from buffer in
+    /// memory/stack
     /**
      * @param pBuffer uint 8 bit flat buffer for image
      * @param attachmentFileName if the parameter is not empty, the browser

--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -357,9 +357,9 @@ class HttpResponse
     /// memory/stack
     /**
      * @param pBuffer uint 8 bit flat buffer for image
+     * @param bufferLength length of expected buffer
      * @param attachmentFileName if the parameter is not empty, the browser
      * @param type if the parameter is CT_NONE, the content type is set by
-     * @param bufferLength length of expected buffer
      * drogon based on the file extension.
      */
     static HttpResponsePtr newFileResponse(

--- a/lib/inc/drogon/HttpResponse.h
+++ b/lib/inc/drogon/HttpResponse.h
@@ -356,9 +356,10 @@ class HttpResponse
     /// Create a response that returns a file to the client from buffer in
     /// memory/stack
     /**
-     * @param pBuffer uint 8 bit flat buffer for image
-     * @param bufferLength length of expected buffer
+     * @param pBuffer is a uint 8 bit flat buffer for object/files in memory
+     * @param bufferLength is the length of the expected buffer
      * @param attachmentFileName if the parameter is not empty, the browser
+     * does not open the file, but saves it as an attachment.
      * @param type if the parameter is CT_NONE, the content type is set by
      * drogon based on the file extension.
      */

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -189,6 +189,44 @@ HttpResponsePtr HttpResponse::newHttpViewResponse(const std::string &viewName,
 }
 
 HttpResponsePtr HttpResponse::newFileResponse(
+    const unsigned char *pBuffer,
+    size_t bufferLength,
+    const std::string &attachmentFileName,
+    ContentType type)
+{   
+    // Make Raw HttpResponse
+    auto resp = std::make_shared<HttpResponseImpl>();
+
+    // Set response body and length
+    resp->setBody(std::string(reinterpret_cast<const char *>(pBuffer),bufferLength));
+
+    // Set status of message
+    resp->setStatusCode(k200OK);
+
+    // Check for type and assign proper content type in header
+    if (!attachmentFileName.empty())
+    {
+        resp->setContentTypeCode(
+            drogon::getContentType(attachmentFileName));
+    }
+    else
+    {
+            resp->setContentTypeCode(type);
+    }
+
+    // Add additional header values
+    if (!attachmentFileName.empty())
+    {
+        resp->addHeader("Content-Disposition",
+                        "attachment; filename=" + attachmentFileName);
+    }
+    
+    // Finalize and return response
+    doResponseCreateAdvices(resp);
+    return resp;
+}
+
+HttpResponsePtr HttpResponse::newFileResponse(
     const std::string &fullPath,
     const std::string &attachmentFileName,
     ContentType type)

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -215,7 +215,8 @@ HttpResponsePtr HttpResponse::newFileResponse(
     }
     else
     {
-        resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);//default content-type for file;
+        resp->setContentTypeCode(
+            CT_APPLICATION_OCTET_STREAM);  // default content-type for file;
     }
 
     // Add additional header values

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -193,12 +193,13 @@ HttpResponsePtr HttpResponse::newFileResponse(
     size_t bufferLength,
     const std::string &attachmentFileName,
     ContentType type)
-{   
+{
     // Make Raw HttpResponse
     auto resp = std::make_shared<HttpResponseImpl>();
 
     // Set response body and length
-    resp->setBody(std::string(reinterpret_cast<const char *>(pBuffer),bufferLength));
+    resp->setBody(
+        std::string(reinterpret_cast<const char *>(pBuffer),bufferLength));
 
     // Set status of message
     resp->setStatusCode(k200OK);
@@ -206,12 +207,11 @@ HttpResponsePtr HttpResponse::newFileResponse(
     // Check for type and assign proper content type in header
     if (!attachmentFileName.empty())
     {
-        resp->setContentTypeCode(
-            drogon::getContentType(attachmentFileName));
+        resp->setContentTypeCode(drogon::getContentType(attachmentFileName));
     }
     else
     {
-            resp->setContentTypeCode(type);
+        resp->setContentTypeCode(type);
     }
 
     // Add additional header values
@@ -220,7 +220,7 @@ HttpResponsePtr HttpResponse::newFileResponse(
         resp->addHeader("Content-Disposition",
                         "attachment; filename=" + attachmentFileName);
     }
-    
+
     // Finalize and return response
     doResponseCreateAdvices(resp);
     return resp;

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -205,13 +205,17 @@ HttpResponsePtr HttpResponse::newFileResponse(
     resp->setStatusCode(k200OK);
 
     // Check for type and assign proper content type in header
-    if (!attachmentFileName.empty())
+    if (type != CT_NONE)
+    {
+        resp->setContentTypeCode(type);
+    }
+    else if (!attachmentFileName.empty())
     {
         resp->setContentTypeCode(drogon::getContentType(attachmentFileName));
     }
     else
     {
-        resp->setContentTypeCode(type);
+        resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);//default content-type for file;
     }
 
     // Add additional header values

--- a/lib/src/HttpResponseImpl.cc
+++ b/lib/src/HttpResponseImpl.cc
@@ -199,7 +199,7 @@ HttpResponsePtr HttpResponse::newFileResponse(
 
     // Set response body and length
     resp->setBody(
-        std::string(reinterpret_cast<const char *>(pBuffer),bufferLength));
+        std::string(reinterpret_cast<const char *>(pBuffer), bufferLength));
 
     // Set status of message
     resp->setStatusCode(k200OK);


### PR DESCRIPTION
newFileResponse only supports loading objects from storage or saved, with this additional function call you can now pass files that are loaded in memory like images which are being processed for example.