### PR TITLE
Catch exceptions thrown by handlers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ set(DROGON_SOURCES
     lib/src/DrTemplateBase.cc
     lib/src/FiltersFunction.cc
     lib/src/HttpAppFrameworkImpl.cc
+    lib/src/HttpBinder.cc
     lib/src/HttpClientImpl.cc
     lib/src/HttpControllersRouter.cc
     lib/src/HttpFileImpl.cc

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -205,6 +205,12 @@ int main()
                        int)>
         func = std::bind(&A::handle, &tmp, _1, _2, _3, _4, _5, _6);
     app().registerHandler("/api/v1/handle4/{4:p4}/{3:p3}/{1:p1}", func);
+    app().registerHandler(
+        "/api/v1/this_will_fail",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback) {
+            throw std::runtime_error("this should fail");
+        });
 
     app().setDocumentRoot("./");
     app().enableSession(60);

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -1303,6 +1303,27 @@ void doTest(const HttpClientPtr &client,
                 exit(1);
             }
         });
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/api/v1/this_will_fail");
+    client->sendRequest(
+        req, [req, isHttps](ReqResult result, const HttpResponsePtr &resp) {
+            if (result == ReqResult::Ok)
+            {
+                if (resp->getStatusCode() != k500InternalServerError)
+                {
+                    LOG_DEBUG << resp->getStatusCode();
+                    LOG_ERROR << "Error!";
+                    exit(1);
+                }
+                outputGood(req, isHttps);
+            }
+            else
+            {
+                LOG_ERROR << "Error!";
+                exit(1);
+            }
+        });
 
 #ifdef __cpp_impl_coroutine
     // Test coroutine requests

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -57,7 +57,7 @@ class HttpControllerBase;
 class HttpSimpleControllerBase;
 class WebSocketControllerBase;
 using ExceptionHandler =
-    std::function<void(std::exception_ptr,
+    std::function<void(const std::exception &,
                        const HttpRequestPtr &,
                        std::function<void(const HttpResponsePtr &)> &&)>;
 

--- a/lib/inc/drogon/HttpAppFramework.h
+++ b/lib/inc/drogon/HttpAppFramework.h
@@ -56,6 +56,10 @@ std::string getGitCommit();
 class HttpControllerBase;
 class HttpSimpleControllerBase;
 class WebSocketControllerBase;
+using ExceptionHandler =
+    std::function<void(std::exception_ptr,
+                       const HttpRequestPtr &,
+                       std::function<void(const HttpResponsePtr &)> &&)>;
 
 class HttpAppFramework : public trantor::NonCopyable
 {
@@ -1292,6 +1296,16 @@ class HttpAppFramework : public trantor::NonCopyable
      * @brief Return if the ReusePort mode is enabled.
      */
     virtual bool reusePort() const = 0;
+
+    /**
+     * @brief handler will be called upon an exception escapes a request handler
+     */
+    virtual void setExceptionHandler(ExceptionHandler handler) = 0;
+
+    /**
+     * @brief returns the excaption handler
+     */
+    virtual const ExceptionHandler &getExceptionHandler() const = 0;
 
   private:
     virtual void registerHttpController(

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -240,7 +240,7 @@ class HttpBinder : public HttpBinderBase
             pathArguments.pop_front();
             try
             {
-                if(value.empty() == false)
+                if(v.empty() == false)
                     getHandlerArgumentValue(value, std::move(v));
             }
             catch (const std::exception &e)

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -242,10 +242,12 @@ class HttpBinder : public HttpBinderBase
             {
                 getHandlerArgumentValue(value, std::move(v));
             }
-            catch (...)
+            catch (const std::exception &)
             {
-                LOG_ERROR << "Error converting string \"" << v << "\" to the "
-                          << sizeof...(Values) + 1 << "th argument";
+                handleException(std::current_exception(),
+                                req,
+                                std::move(callback));
+                return;
             }
         }
         else

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -240,7 +240,7 @@ class HttpBinder : public HttpBinderBase
             pathArguments.pop_front();
             try
             {
-                if(v.empty() == false)
+                if (v.empty() == false)
                     getHandlerArgumentValue(value, std::move(v));
             }
             catch (const std::exception &e)

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -240,7 +240,8 @@ class HttpBinder : public HttpBinderBase
             pathArguments.pop_front();
             try
             {
-                getHandlerArgumentValue(value, std::move(v));
+                if(value.empty() == false)
+                    getHandlerArgumentValue(value, std::move(v));
             }
             catch (const std::exception &e)
             {

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -118,6 +118,15 @@ HttpResponsePtr defaultErrorHandler(HttpStatusCode code)
     return std::make_shared<HttpResponseImpl>(code, CT_TEXT_HTML);
 }
 
+void defaultExceptionHandler(
+    std::exception_ptr e,
+    const HttpRequestPtr &req,
+    std::function<void(const HttpResponsePtr &)> &&callback)
+{
+    auto handler = app().getCustomErrorHandler();
+    callback(handler(k500InternalServerError));
+}
+
 static void godaemon()
 {
     printf("Initializing daemon mode\n");

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -119,7 +119,7 @@ HttpResponsePtr defaultErrorHandler(HttpStatusCode code)
 }
 
 void defaultExceptionHandler(
-    std::exception_ptr e,
+    const std::exception &e,
     const HttpRequestPtr &req,
     std::function<void(const HttpResponsePtr &)> &&callback)
 {

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -125,7 +125,7 @@ void defaultExceptionHandler(
 {
     LOG_ERROR << "Unhandled exception in " << req->query()
               << ", what():" << e.what();
-    const auto& handler = app().getCustomErrorHandler();
+    const auto &handler = app().getCustomErrorHandler();
     callback(handler(k500InternalServerError));
 }
 

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -125,7 +125,7 @@ void defaultExceptionHandler(
 {
     LOG_ERROR << "Unhandled exception in " << req->query()
               << ", what():" << e.what();
-    auto handler = app().getCustomErrorHandler();
+    const auto& handler = app().getCustomErrorHandler();
     callback(handler(k500InternalServerError));
 }
 

--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -123,6 +123,8 @@ void defaultExceptionHandler(
     const HttpRequestPtr &req,
     std::function<void(const HttpResponsePtr &)> &&callback)
 {
+    LOG_ERROR << "Unhandled exception in " << req->query()
+              << ", what():" << e.what();
     auto handler = app().getCustomErrorHandler();
     callback(handler(k500InternalServerError));
 }

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -29,7 +29,7 @@
 namespace drogon
 {
 HttpResponsePtr defaultErrorHandler(HttpStatusCode code);
-void defaultExceptionHandler(std::exception_ptr,
+void defaultExceptionHandler(const std::exception &,
                              const HttpRequestPtr &,
                              std::function<void(const HttpResponsePtr &)> &&);
 
@@ -639,7 +639,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         postRoutingObservers_;
     std::vector<std::function<void(const HttpRequestPtr &)>>
         preHandlingObservers_;
-    ExceptionHandler exceptionHandler_ = defaultExceptionHandler;
+    ExceptionHandler exceptionHandler_{defaultExceptionHandler};
 };
 
 }  // namespace drogon

--- a/lib/src/HttpAppFrameworkImpl.h
+++ b/lib/src/HttpAppFrameworkImpl.h
@@ -29,6 +29,9 @@
 namespace drogon
 {
 HttpResponsePtr defaultErrorHandler(HttpStatusCode code);
+void defaultExceptionHandler(std::exception_ptr,
+                             const HttpRequestPtr &,
+                             std::function<void(const HttpResponsePtr &)> &&);
 
 struct InitBeforeMainFunction
 {
@@ -505,6 +508,16 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         return reusePort_;
     }
 
+    void setExceptionHandler(ExceptionHandler handler) override
+    {
+        exceptionHandler_ = std::move(handler);
+    }
+
+    const ExceptionHandler &getExceptionHandler() const override
+    {
+        return exceptionHandler_;
+    }
+
   private:
     void registerHttpController(const std::string &pathPattern,
                                 const internal::HttpBinderBasePtr &binder,
@@ -626,6 +639,7 @@ class HttpAppFrameworkImpl final : public HttpAppFramework
         postRoutingObservers_;
     std::vector<std::function<void(const HttpRequestPtr &)>>
         preHandlingObservers_;
+    ExceptionHandler exceptionHandler_ = defaultExceptionHandler;
 };
 
 }  // namespace drogon

--- a/lib/src/HttpBinder.cc
+++ b/lib/src/HttpBinder.cc
@@ -19,7 +19,7 @@ namespace drogon
 {
 namespace internal
 {
-void handleException(std::exception_ptr e,
+void handleException(const std::exception& e,
                      const HttpRequestPtr& req,
                      std::function<void(const HttpResponsePtr&)>&& callback)
 {

--- a/lib/src/HttpBinder.cc
+++ b/lib/src/HttpBinder.cc
@@ -1,0 +1,29 @@
+/**
+ *
+ *  HttpBinder.h
+ *  Martin Chang
+ *
+ *  Copyright 2021, Martin Chang.  All rights reserved.
+ *  https://github.com/an-tao/drogon
+ *  Use of this source code is governed by a MIT license
+ *  that can be found in the License file.
+ *
+ *  Drogon
+ *
+ */
+
+#include <drogon/HttpBinder.h>
+#include <drogon/HttpAppFramework.h>
+
+namespace drogon
+{
+namespace internal
+{
+void handleException(std::exception_ptr e,
+                     const HttpRequestPtr& req,
+                     std::function<void(const HttpResponsePtr&)>&& callback)
+{
+    app().getExceptionHandler()(e, req, std::move(callback));
+}
+}  // namespace internal
+}  // namespace drogon


### PR DESCRIPTION
Fix #600 #757

I'd to work around the circular header includes in HttpBinder and HttpAppFramework. And I think this needs some discussion. Passing `std::exception_ptr` doesn't allow users to read the exception message directly. Yet this is the only way to also handle exceptions not derived from `std::exception`