### PR TITLE
Use lambda instead of std::bind in HttpServer

### DIFF
--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -166,9 +166,9 @@ HttpServer::HttpServer(
       syncAdvices_(syncAdvices)
 {
     server_.setConnectionCallback(
-        [this](const auto &conn) { onConnection(conn); });
+        [this](const auto &conn) { this->onConnection(conn); });
     server_.setRecvMessageCallback(
-        [this](const auto &conn, auto buff) { onMessage(conn, buff); });
+        [this](const auto &conn, auto buff) { this->onMessage(conn, buff); });
 }
 
 HttpServer::~HttpServer()

--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -166,9 +166,9 @@ HttpServer::HttpServer(
       syncAdvices_(syncAdvices)
 {
     server_.setConnectionCallback(
-        std::bind(&HttpServer::onConnection, this, _1));
+        [this](const auto &conn) { onConnection(conn); });
     server_.setRecvMessageCallback(
-        std::bind(&HttpServer::onMessage, this, _1, _2));
+        [this](const auto &conn, auto buff) { onMessage(conn, buff); });
 }
 
 HttpServer::~HttpServer()


### PR DESCRIPTION
This PR replaces std::bind with lambdas in HttpServer.cc as lambdas are faster than bind. Should be faster overall but I'm not sure if the effect will be visible. I tried to also apply it elsewhere but can't compile properly without large code changes.