### PR TITLE
Little changes

### DIFF
--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -214,7 +214,8 @@ void HttpRequestImpl::appendToBuffer(trantor::MsgBuffer *output) const
         output->append("?");
         output->append(query_);
     }
-    if (!passThrough_ && !parameters_.empty())
+    if (!passThrough_ && !parameters_.empty() &&
+        contentType_ != CT_MULTIPART_FORM_DATA)
     {
         for (auto const &p : parameters_)
         {

--- a/lib/src/HttpRequestImpl.cc
+++ b/lib/src/HttpRequestImpl.cc
@@ -209,9 +209,12 @@ void HttpRequestImpl::appendToBuffer(trantor::MsgBuffer *output) const
     }
 
     std::string content;
-
-    if (!passThrough_ &&
-        (!parameters_.empty() && contentType_ != CT_MULTIPART_FORM_DATA))
+    if (passThrough_ && !query_.empty())
+    {
+        output->append("?");
+        output->append(query_);
+    }
+    if (!passThrough_ && !parameters_.empty())
     {
         for (auto const &p : parameters_)
         {
@@ -221,7 +224,7 @@ void HttpRequestImpl::appendToBuffer(trantor::MsgBuffer *output) const
             content.append("&");
         }
         content.resize(content.length() - 1);
-        if (method_ == Get || method_ == Delete || method_ == Head)
+        if (contentType_ != CT_APPLICATION_X_FORM)
         {
             auto ret = std::find(output->peek(),
                                  (const char *)output->beginWrite(),
@@ -238,18 +241,6 @@ void HttpRequestImpl::appendToBuffer(trantor::MsgBuffer *output) const
                 output->append("?");
             }
             output->append(content);
-            content.clear();
-        }
-        else if (contentType_ == CT_APPLICATION_JSON)
-        {
-            /// Can't set parameters in content in this case
-            LOG_ERROR
-                << "You can't set parameters in the query string when the "
-                   "request content type is JSON and http method "
-                   "is POST or PUT";
-            LOG_ERROR << "Please put these parameters into the path or "
-                         "into the json "
-                         "string";
             content.clear();
         }
     }

--- a/lib/src/MultiPart.cc
+++ b/lib/src/MultiPart.cc
@@ -50,7 +50,7 @@ const std::map<std::string, std::string> &MultiPartParser::getParameters() const
 
 int MultiPartParser::parse(const HttpRequestPtr &req)
 {
-    if (req->method() != Post)
+    if (req->method() != Post && req->method() != Put)
         return -1;
     const std::string &contentType =
         static_cast<HttpRequestImpl *>(req.get())->getHeaderBy("content-type");


### PR DESCRIPTION
1. Put parameters in query string if the content-type is not 'application/x-www-form-urlencoded'
2. Parse the multipart form data if the method is POST or PUT (#799)
3. Send query string when the passThrough flag is set