### PR TITLE
Disallow coroutines to be resolved as plain subroutine handlers

### DIFF
--- a/lib/inc/drogon/utils/FunctionTraits.h
+++ b/lib/inc/drogon/utils/FunctionTraits.h
@@ -33,7 +33,6 @@ using HttpResponsePtr = std::shared_ptr<HttpResponse>;
 
 namespace internal
 {
-
 #ifdef __cpp_impl_coroutine
 template <typename T>
 using resumable_type = is_resumable<T>;

--- a/lib/inc/drogon/utils/FunctionTraits.h
+++ b/lib/inc/drogon/utils/FunctionTraits.h
@@ -122,7 +122,7 @@ struct FunctionTraits<
                   std::function<void(const HttpResponsePtr &)> callback,
                   Arguments...)> : FunctionTraits<AsyncTask (*)(Arguments...)>
 {
-    static const bool isHTTPFunction = !resumable_type<ReturnType>::value;
+    static const bool isHTTPFunction = true;
     static const bool isCoroutine = true;
     using class_type = void;
     using first_param_type = HttpRequestPtr;
@@ -134,7 +134,7 @@ struct FunctionTraits<
                std::function<void(const HttpResponsePtr &)> callback,
                Arguments...)> : FunctionTraits<AsyncTask (*)(Arguments...)>
 {
-    static const bool isHTTPFunction = !resumable_type<ReturnType>::value;
+    static const bool isHTTPFunction = true;
     static const bool isCoroutine = true;
     using class_type = void;
     using first_param_type = HttpRequestPtr;
@@ -145,7 +145,7 @@ struct FunctionTraits<Task<HttpResponsePtr> (*)(HttpRequestPtr req,
                                                 Arguments...)>
     : FunctionTraits<AsyncTask (*)(Arguments...)>
 {
-    static const bool isHTTPFunction = !resumable_type<ReturnType>::value;
+    static const bool isHTTPFunction = true;
     static const bool isCoroutine = true;
     using class_type = void;
     using first_param_type = HttpRequestPtr;

--- a/lib/inc/drogon/utils/FunctionTraits.h
+++ b/lib/inc/drogon/utils/FunctionTraits.h
@@ -98,7 +98,7 @@ struct FunctionTraits<
                    std::function<void(const HttpResponsePtr &)> &&callback,
                    Arguments...)> : FunctionTraits<ReturnType (*)(Arguments...)>
 {
-    static const bool isHTTPFunction = !resumable_type<ReturnType>;
+    static const bool isHTTPFunction = !resumable_type<ReturnType>::value;
     static const bool isCoroutine = false;
     using class_type = void;
     using first_param_type = HttpRequestPtr;

--- a/lib/inc/drogon/utils/FunctionTraits.h
+++ b/lib/inc/drogon/utils/FunctionTraits.h
@@ -33,6 +33,17 @@ using HttpResponsePtr = std::shared_ptr<HttpResponse>;
 
 namespace internal
 {
+
+#ifdef __cpp_impl_coroutine
+template <typename T>
+using resumable_type = is_resumable<T>;
+#else
+template <typename T>
+struct resumable_type : std::false_type
+{
+};
+#endif
+
 template <typename>
 struct FunctionTraits;
 
@@ -87,11 +98,7 @@ struct FunctionTraits<
                    std::function<void(const HttpResponsePtr &)> &&callback,
                    Arguments...)> : FunctionTraits<ReturnType (*)(Arguments...)>
 {
-    #ifdef __cpp_impl_coroutine
-    static const bool isHTTPFunction = !is_resumable_v<ReturnType>;
-    #else
-    static const bool isHTTPFunction = true;
-    #endif
+    static const bool isHTTPFunction = !resumable_type<ReturnType>;
     static const bool isCoroutine = false;
     using class_type = void;
     using first_param_type = HttpRequestPtr;
@@ -115,7 +122,7 @@ struct FunctionTraits<
                   std::function<void(const HttpResponsePtr &)> callback,
                   Arguments...)> : FunctionTraits<AsyncTask (*)(Arguments...)>
 {
-    static const bool isHTTPFunction = true;
+    static const bool isHTTPFunction = !resumable_type<ReturnType>::value;
     static const bool isCoroutine = true;
     using class_type = void;
     using first_param_type = HttpRequestPtr;
@@ -127,7 +134,7 @@ struct FunctionTraits<
                std::function<void(const HttpResponsePtr &)> callback,
                Arguments...)> : FunctionTraits<AsyncTask (*)(Arguments...)>
 {
-    static const bool isHTTPFunction = true;
+    static const bool isHTTPFunction = !resumable_type<ReturnType>::value;
     static const bool isCoroutine = true;
     using class_type = void;
     using first_param_type = HttpRequestPtr;
@@ -138,7 +145,7 @@ struct FunctionTraits<Task<HttpResponsePtr> (*)(HttpRequestPtr req,
                                                 Arguments...)>
     : FunctionTraits<AsyncTask (*)(Arguments...)>
 {
-    static const bool isHTTPFunction = true;
+    static const bool isHTTPFunction = !resumable_type<ReturnType>::value;
     static const bool isCoroutine = true;
     using class_type = void;
     using first_param_type = HttpRequestPtr;
@@ -163,7 +170,7 @@ struct FunctionTraits<
                    std::function<void(const HttpResponsePtr &)> &&callback,
                    Arguments...)> : FunctionTraits<ReturnType (*)(Arguments...)>
 {
-    static const bool isHTTPFunction = true;
+    static const bool isHTTPFunction = !resumable_type<ReturnType>::value;
     static const bool isCoroutine = false;
     using class_type = void;
     using first_param_type = T;

--- a/lib/inc/drogon/utils/FunctionTraits.h
+++ b/lib/inc/drogon/utils/FunctionTraits.h
@@ -87,7 +87,11 @@ struct FunctionTraits<
                    std::function<void(const HttpResponsePtr &)> &&callback,
                    Arguments...)> : FunctionTraits<ReturnType (*)(Arguments...)>
 {
+    #ifdef __cpp_impl_coroutine
+    static const bool isHTTPFunction = !is_resumable_v<ReturnType>;
+    #else
     static const bool isHTTPFunction = true;
+    #endif
     static const bool isCoroutine = false;
     using class_type = void;
     using first_param_type = HttpRequestPtr;

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -117,7 +117,7 @@ struct [[nodiscard]] Task
             coro_.destroy();
     }
     Task &operator=(const Task &) = delete;
-    Task &operator=(Task && other)
+    Task &operator=(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -264,7 +264,7 @@ struct [[nodiscard]] Task<void>
             coro_.destroy();
     }
     Task &operator=(const Task &) = delete;
-    Task &operator=(Task && other)
+    Task &operator=(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -610,4 +610,28 @@ inline internal::TimerAwaiter sleepCoro(trantor::EventLoop *loop,
     return internal::TimerAwaiter(loop, delay);
 }
 
+template <typename T, typename = std::void_t<>>
+struct is_resumable : std::false_type
+{
+};
+
+template <typename T>
+struct is_resumable<
+    T,
+    std::void_t<decltype(internal::getAwaiter(std::declval<T>()))>>
+    : std::true_type
+{
+};
+
+template <>
+struct is_resumable<
+    AsyncTask,
+    std::void_t<AsyncTask>>
+    : std::true_type
+{
+};
+
+template <typename T>
+constexpr bool is_resumable_v = is_resumable<T>::value;
+
 }  // namespace drogon

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -106,7 +106,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task && other)
+    Task(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -253,7 +253,7 @@ struct [[nodiscard]] Task<void>
     {
     }
     Task(const Task &) = delete;
-    Task(Task && other)
+    Task(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -624,10 +624,7 @@ struct is_resumable<
 };
 
 template <>
-struct is_resumable<
-    AsyncTask,
-    std::void_t<AsyncTask>>
-    : std::true_type
+struct is_resumable<AsyncTask, std::void_t<AsyncTask>> : std::true_type
 {
 };
 

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -106,7 +106,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -117,7 +117,7 @@ struct [[nodiscard]] Task
             coro_.destroy();
     }
     Task &operator=(const Task &) = delete;
-    Task &operator=(Task &&other)
+    Task &operator=(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -253,7 +253,7 @@ struct [[nodiscard]] Task<void>
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -264,7 +264,7 @@ struct [[nodiscard]] Task<void>
             coro_.destroy();
     }
     Task &operator=(const Task &) = delete;
-    Task &operator=(Task &&other)
+    Task &operator=(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;


### PR DESCRIPTION
Related to #821. Coroutines with type `Task<>(const HttpRequestPtr&, HandlerCallback&&, Args....)` are wrongfully recognized as a handler (even though one should always pass by value or r-value ref) into a coroutine. This is caused by FunctionTraits managed to find an unexpected match while SFIANE`. Namely:

```c++
// normal function for HTTP handling
template <typename ReturnType, typename... Arguments>
struct FunctionTraits<
    ReturnType (*)(const HttpRequestPtr &req,
                   std::function<void(const HttpResponsePtr &)> &&callback,
                   Arguments...)> : FunctionTraits<ReturnType (*)(Arguments...)>
{
    static const bool isHTTPFunction = true;
    static const bool isCoroutine = false;
    using class_type = void;
    using first_param_type = HttpRequestPtr;
    using return_type = ReturnType;
};
```

In this case `Task<>` is recognized as the return value of the handler. (The handler is treated as a function instead of a coroutine)


In short: These test should have passed. But they don't. This PR fixes it.

```C++
static_assert(FunctionTraits<Task<>(*)(const HttpRequestPtr&, HandlerCallback&&)>::isHTTPFunction == false);
static_assert(FunctionTraits<AsyncTask(*)(const HttpRequestPtr&, HandlerCallback&&)>::isHTTPFunction == false);
```