### PR TITLE
Reduce overhead in ORM error handling

### DIFF
--- a/orm_lib/src/DbClientImpl.cc
+++ b/orm_lib/src/DbClientImpl.cc
@@ -210,14 +210,9 @@ void DbClientImpl::execSql(
     }
     if (busy)
     {
-        try
-        {
-            throw Failure("Too many queries in buffer");
-        }
-        catch (...)
-        {
-            exceptCallback(std::current_exception());
-        }
+        auto exceptPtr =
+            std::make_exception_ptr(Failure("Too many queries in buffer"));
+        exceptCallback(exceptPtr);
         return;
     }
 }

--- a/orm_lib/src/DbClientLockFree.cc
+++ b/orm_lib/src/DbClientLockFree.cc
@@ -17,6 +17,7 @@
 #include "TransactionImpl.h"
 #include "../../lib/src/TaskTimeoutFlag.h"
 #include <drogon/config.h>
+#include <exception>
 #if USE_POSTGRESQL
 #include "postgresql_impl/PgConnection.h"
 #endif
@@ -191,14 +192,9 @@ void DbClientLockFree::execSql(
     if (sqlCmdBuffer_.size() > 20000)
     {
         // too many queries in buffer;
-        try
-        {
-            throw Failure("Too many queries in buffer");
-        }
-        catch (...)
-        {
-            exceptCallback(std::current_exception());
-        }
+        auto exceptPtr =
+            std::make_exception_ptr(Failure("Too many queries in buffer"));
+        exceptCallback(exceptPtr);
         return;
     }
 

--- a/orm_lib/src/mysql_impl/MysqlConnection.cc
+++ b/orm_lib/src/mysql_impl/MysqlConnection.cc
@@ -15,6 +15,7 @@
 #include "MysqlConnection.h"
 #include "MysqlResultImpl.h"
 #include <algorithm>
+#include <exception>
 #include <drogon/orm/DbTypes.h>
 #include <drogon/utils/Utilities.h>
 #include <drogon/utils/string_view.h>
@@ -532,16 +533,11 @@ void MysqlConnection::outputError()
 
     if (isWorking_)
     {
-        try
-        {
-            // TODO: exception type
-            throw SqlError(mysql_error(mysqlPtr_.get()), sql_);
-        }
-        catch (...)
-        {
-            exceptionCallback_(std::current_exception());
-            exceptionCallback_ = nullptr;
-        }
+        // TODO: exception type
+        auto exceptPtr = std::make_exception_ptr(
+            SqlError(mysql_error(mysqlPtr_.get()), sql_));
+        exceptionCallback_(exceptPtr);
+        exceptionCallback_ = nullptr;
 
         callback_ = nullptr;
         isWorking_ = false;

--- a/orm_lib/src/postgresql_impl/PgConnection.cc
+++ b/orm_lib/src/postgresql_impl/PgConnection.cc
@@ -376,16 +376,10 @@ void PgConnection::doAfterPreparing()
 
 void PgConnection::handleFatalError()
 {
-    try
-    {
-        throw Failure(PQerrorMessage(connectionPtr_.get()));
-    }
-    catch (...)
-    {
-        auto exceptPtr = std::current_exception();
-        exceptionCallback_(exceptPtr);
-        exceptionCallback_ = nullptr;
-    }
+    auto exceptPtr =
+        std::make_exception_ptr(Failure(PQerrorMessage(connectionPtr_.get())));
+    exceptionCallback_(exceptPtr);
+    exceptionCallback_ = nullptr;
 }
 
 void PgConnection::batchSql(std::deque<std::shared_ptr<SqlCmd>> &&)


### PR DESCRIPTION
This PR reduces the overhead when an error happens in SQL. It replaces all the `try { throw } catch { func(std::current_exception())}` block with`std::make_exception_ptr`. This has a lower overhead as shown in the figure.

![Screenshot from 2021-04-29 12-00-53](https://user-images.githubusercontent.com/8792393/116501117-9624c700-a8e2-11eb-99ce-aa1e1d451457.png)

*Note:* it has the potential to break old code. Now the error handlers aren't called with an active exception. Thus `std::current_exception()` returns nullptr. I don't except anyone doing this since we pass the exception as a parameter. But still a note worthy point.