### PR TITLE
Remove duplicated inclusion

### DIFF
--- a/lib/src/HttpAppFrameworkImpl.cc
+++ b/lib/src/HttpAppFrameworkImpl.cc
@@ -21,7 +21,6 @@
 #include "HttpSimpleControllersRouter.h"
 #include "HttpControllersRouter.h"
 #include "WebsocketControllersRouter.h"
-#include "HttpClientImpl.h"
 #include "AOPAdvice.h"
 #include "ConfigLoader.h"
 #include "HttpServer.h"


### PR DESCRIPTION
This remove the duplicated `#include "HttpClientImpl.h"` in `lib/src/HttpAppFrameworkImpl.cc`.

Also, I've noticed that there are some `#include <stdio.h>`  or something similar. Should we change them to `#include <cstdio>`?