### PR TITLE
Print error before terminating in AsyncTask

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -15,6 +15,7 @@
 
 #include <drogon/utils/optional.h>
 #include <trantor/net/EventLoop.h>
+#include <trantor/utils/Logger.h>
 #include <algorithm>
 #include <coroutine>
 #include <exception>
@@ -395,6 +396,7 @@ struct AsyncTask final
 
         void unhandled_exception()
         {
+            LOG_FATAL << "Unhandled excption in AsyncTask";
             std::terminate();
         }
 

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -396,7 +396,7 @@ struct AsyncTask final
 
         void unhandled_exception()
         {
-            LOG_FATAL << "Unhandled excption in AsyncTask";
+            LOG_FATAL << "Exception escaping AsyncTask";
             std::terminate();
         }
 


### PR DESCRIPTION
Prints a fatal error when exceptions escapes AsyncTask. To make the cause of crash is such case obvious.