### PR TITLE
Allow users to override drogon Find modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ else ()
     message(STATUS "use c++20")
 endif ()
 
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)
 
 # jsoncpp
 find_package(Jsoncpp REQUIRED)


### PR DESCRIPTION
Instead of completely changing the `CMAKE_MODULE_PATH` with `${PROJECT_SOURCE_DIR}/cmake_modules/`, append it to the list so that users can decide to provide their own `Find<module>.cmake` file.

If the user does not provide some or all files, everything will still work as intended, drogon find modules will be used instead.