### PR TITLE
add missing include mutex

### DIFF
--- a/lib/inc/drogon/PubSubService.h
+++ b/lib/inc/drogon/PubSubService.h
@@ -15,10 +15,11 @@
 #pragma once
 
 #include <trantor/utils/NonCopyable.h>
+#include <functional>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
-#include <functional>
-#include <shared_mutex>
 
 namespace drogon
 {

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -17,13 +17,14 @@
 #include <trantor/net/EventLoop.h>
 #include <trantor/utils/Logger.h>
 #include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <condition_variable>
 #include <coroutine>
 #include <exception>
-#include <type_traits>
-#include <condition_variable>
-#include <atomic>
 #include <future>
-#include <cassert>
+#include <mutex>
+#include <type_traits>
 
 namespace drogon
 {

--- a/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
+++ b/orm_lib/src/sqlite3_impl/Sqlite3Connection.cc
@@ -16,9 +16,10 @@
 #include "Sqlite3ResultImpl.h"
 #include <drogon/utils/Utilities.h>
 #include <drogon/utils/string_view.h>
-#include <exception>
-#include <regex>
 #include <cctype>
+#include <exception>
+#include <mutex>
+#include <regex>
 
 using namespace drogon;
 using namespace drogon::orm;


### PR DESCRIPTION
Added missing `#include <mutex>` for `std::unique_lock` references.  Was getting compile errors on g++ 11 after my upgrade from Fedora 33 to 34.   Just the first error is below.

https://en.cppreference.com/w/cpp/thread/unique_lock

```
In file included from /home/phil/Fedora/drogon/drogon-1.5.1/unittest/PubSubServiceUnittest.cpp:2:
/home/phil/Fedora/drogon/drogon-1.5.1/lib/inc/drogon/PubSubService.h: In member function ‘drogon::SubscriberID drogon::Topic<MessageType>::subscribe(const MessageHandler&)’:
/home/phil/Fedora/drogon/drogon-1.5.1/lib/inc/drogon/PubSubService.h:65:14: error: ‘unique_lock’ is not a member of ‘std’
   65 |         std::unique_lock<SharedMutex> lock(mutex_);
      |              ^~~~~~~~~~~
/home/phil/Fedora/drogon/drogon-1.5.1/lib/inc/drogon/PubSubService.h:22:1: note: ‘std::unique_lock’ is defined in header ‘<mutex>’; did you forget to ‘#include <mutex>’?
   21 | #include <shared_mutex>
  +++ |+#include <mutex>
``` 