### PR TITLE
Fix coroutine frame leak upon assigning to resumable

### DIFF
--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -121,6 +121,11 @@ struct [[nodiscard]] Task
     Task &operator=(const Task &) = delete;
     Task &operator=(Task &&other)
     {
+        if (std::addressof(other) == this)
+            return *this;
+        if (coro_)
+            coro_.destroy();
+
         coro_ = other.coro_;
         other.coro_ = nullptr;
         return *this;
@@ -268,6 +273,11 @@ struct [[nodiscard]] Task<void>
     Task &operator=(const Task &) = delete;
     Task &operator=(Task &&other)
     {
+        if (std::addressof(other) == this)
+            return *this;
+        if (coro_)
+            coro_.destroy();
+
         coro_ = other.coro_;
         other.coro_ = nullptr;
         return *this;
@@ -533,6 +543,7 @@ auto sync_wait(AWAIT &&await)
                 exception_ptr = std::current_exception();
             }
             flag = true;
+            cv.notify_one();
         }();
 
         std::unique_lock lk(mtx);


### PR DESCRIPTION
This PR a bugs in the coroutine library. Move-assigning to an existing Task<> will cause coroutine frame leak. Ex:

```C++
Task<HttpResponsePtr> resp_awaiter = client->sendRequestCoro(....);
auto resp = co_await resp_awaiter;
...

// This causes a coroutien frame leak
resp_awaiter = std::move(client->sendRequestCoro(....)); 
```

This PR fixes it.