### PR TITLE
Fix sync_wait/co_future use-after-free

### DIFF
--- a/examples/simple_example_test/WebSocketCoroTest.cc
+++ b/examples/simple_example_test/WebSocketCoroTest.cc
@@ -74,7 +74,9 @@ int main(int argc, char* argv[])
     });
     app().setLogLevel(trantor::Logger::kTrace);
 
-    [=]() -> AsyncTask { co_await doTest(wsPtr, req, continually); }();
+    auto test = [=]() -> AsyncTask {
+        co_await doTest(wsPtr, req, continually);
+    }();
 
     app().run();
 }

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -1404,7 +1404,7 @@ void doTest(const HttpClientPtr &client,
             LOG_ERROR << "Error!";
             exit(1);
         }
-    }());;
+    }());
 #endif
 }
 void loadFileLengths()

--- a/examples/simple_example_test/main.cc
+++ b/examples/simple_example_test/main.cc
@@ -1361,7 +1361,7 @@ void doTest(const HttpClientPtr &client,
 
 #ifdef __cpp_impl_coroutine
     // Test coroutine requests
-    [client, isHttps]() -> AsyncTask {
+    sync_wait([client, isHttps]() -> Task<> {
         try
         {
             auto req = HttpRequest::newHttpRequest();
@@ -1381,10 +1381,10 @@ void doTest(const HttpClientPtr &client,
             LOG_ERROR << "Error!";
             exit(1);
         }
-    }();
+    }());
 
     // Test coroutine request with co_return
-    [client, isHttps]() -> AsyncTask {
+    sync_wait([client, isHttps]() -> Task<> {
         try
         {
             auto req = HttpRequest::newHttpRequest();
@@ -1404,7 +1404,7 @@ void doTest(const HttpClientPtr &client,
             LOG_ERROR << "Error!";
             exit(1);
         }
-    }();
+    }());;
 #endif
 }
 void loadFileLengths()

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -108,7 +108,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -260,7 +260,7 @@ struct [[nodiscard]] Task<void>
     {
     }
     Task(const Task &) = delete;
-    Task(Task &&other)
+    Task(Task && other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -108,7 +108,7 @@ struct [[nodiscard]] Task
     {
     }
     Task(const Task &) = delete;
-    Task(Task && other)
+    Task(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -260,7 +260,7 @@ struct [[nodiscard]] Task<void>
     {
     }
     Task(const Task &) = delete;
-    Task(Task && other)
+    Task(Task &&other)
     {
         coro_ = other.coro_;
         other.coro_ = nullptr;
@@ -387,43 +387,105 @@ struct [[nodiscard]] Task<void>
 /// destructs
 // NOTE: AsyncTask is designed to be not awaitable. And kills the entire process
 // if exception escaped.
-struct AsyncTask final
+struct AsyncTask
 {
-    struct promise_type final
+    struct promise_type;
+    using handle_type = std::coroutine_handle<promise_type>;
+
+    AsyncTask() = default;
+    AsyncTask(handle_type h) : coro_(h)
     {
-        auto initial_suspend() noexcept
+    }
+    AsyncTask(const AsyncTask &) = delete;
+
+    ~AsyncTask()
+    {
+        if (coro_)
+            coro_.destroy();
+    }
+    AsyncTask &operator=(const AsyncTask &) = delete;
+    AsyncTask &operator=(AsyncTask &&other)
+    {
+        if (std::addressof(other) == this)
+            return *this;
+        if (coro_)
+            coro_.destroy();
+
+        coro_ = other.coro_;
+        other.coro_ = nullptr;
+        return *this;
+    }
+
+    struct promise_type
+    {
+        std::coroutine_handle<> continuation_;
+
+        AsyncTask get_return_object() noexcept
         {
-            return std::suspend_never{};
+            return {std::coroutine_handle<promise_type>::from_promise(*this)};
         }
 
-        auto final_suspend() noexcept
+        std::suspend_never initial_suspend() const noexcept
         {
-            return std::suspend_never{};
+            return {};
+        }
+
+        void unhandled_exception()
+        {
+            LOG_FATAL << "Unhandled exception in AsyncTask.";
+            abort();
         }
 
         void return_void() noexcept
         {
         }
 
-        void unhandled_exception()
+        void setContinuation(std::coroutine_handle<> handle)
         {
-            LOG_FATAL << "Exception escaping AsyncTask";
-            std::terminate();
+            continuation_ = handle;
         }
 
-        promise_type *get_return_object() noexcept
+        auto final_suspend() const noexcept
         {
-            return this;
-        }
+            struct awaiter
+            {
+                bool await_ready() const noexcept
+                {
+                    return false;
+                }
 
-        void result()
-        {
+                void await_resume() const noexcept
+                {
+                }
+
+                std::coroutine_handle<> await_suspend(
+                    std::coroutine_handle<promise_type> handle) noexcept
+                {
+                    auto coro = handle.promise().continuation_;
+                    if (coro)
+                        return coro;
+
+                    return std::noop_coroutine();
+                }
+            };
+            return awaiter{};
         }
     };
-    AsyncTask(const promise_type *) noexcept
+    bool await_ready() const noexcept
     {
-        // the type truncates all given info about its frame
+        return coro_.done();
     }
+
+    void await_resume() const noexcept
+    {
+    }
+
+    void await_suspend(std::coroutine_handle<> coroutine) const noexcept
+    {
+        coro_.promise().setContinuation(coroutine);
+    }
+
+    handle_type coro_;
 };
 
 /// Helper class that provides the infrastructure for turning callback into
@@ -497,21 +559,20 @@ struct CallbackAwaiter<void>
 
 // An ok implementation of sync_await. This allows one to call
 // coroutines and wait for the result from a function.
-//
-// NOTE: Not sure if this is a compiler bug. But causes use after free in some
-// cases. Don't use it in production code.
 template <typename AWAIT>
 auto sync_wait(AWAIT &&await)
 {
+    static_assert(!std::is_same_v<AWAIT, AsyncTask>);
     using value_type = typename await_result<AWAIT>::type;
     std::condition_variable cv;
     std::mutex mtx;
     std::atomic<bool> flag = false;
     std::exception_ptr exception_ptr;
+    std::unique_lock lk(mtx);
 
     if constexpr (std::is_same_v<value_type, void>)
     {
-        [&, lk = std::unique_lock(mtx)]() -> AsyncTask {
+        auto task = [&]() -> AsyncTask {
             try
             {
                 co_await await;
@@ -520,20 +581,23 @@ auto sync_wait(AWAIT &&await)
             {
                 exception_ptr = std::current_exception();
             }
-
+            std::unique_lock lk(mtx);
             flag = true;
-            cv.notify_one();
-        }();
+            cv.notify_all();
+        };
 
-        std::unique_lock lk(mtx);
+        // HACK: Workarround coroutine frame destructing too early by enforcing
+        //       manual lifetime
+        AsyncTask *taskPtr = new AsyncTask{task()};
         cv.wait(lk, [&]() { return (bool)flag; });
+        delete taskPtr;
         if (exception_ptr)
             std::rethrow_exception(exception_ptr);
     }
     else
     {
         optional<value_type> value;
-        [&, lk = std::unique_lock(mtx)]() -> AsyncTask {
+        auto task = [&]() -> AsyncTask {
             try
             {
                 value = co_await await;
@@ -542,14 +606,20 @@ auto sync_wait(AWAIT &&await)
             {
                 exception_ptr = std::current_exception();
             }
+
+            std::unique_lock lk(mtx);
             flag = true;
             cv.notify_one();
-        }();
+        };
 
+        // HACK: Workarround coroutine frame destructing too early by enforcing
+        //       manual lifetime
+        AsyncTask *taskPtr = new AsyncTask{task()};
         std::unique_lock lk(mtx);
         cv.wait(lk, [&]() { return (bool)flag; });
 
         assert(value.has_value() == true || exception_ptr);
+        delete taskPtr;
         if (exception_ptr)
             std::rethrow_exception(exception_ptr);
         return value.value();
@@ -557,8 +627,6 @@ auto sync_wait(AWAIT &&await)
 }
 
 // Converts a task (or task like) promise into std::future for old-style async
-// NOTE: Not sure if this is a compiler bug. But causes use after free in some
-// cases. Don't use it in production code.
 template <typename Await>
 inline auto co_future(Await await) noexcept
     -> std::future<await_result_t<Await>>
@@ -566,7 +634,8 @@ inline auto co_future(Await await) noexcept
     using Result = await_result_t<Await>;
     std::promise<Result> prom;
     auto fut = prom.get_future();
-    [](std::promise<Result> &&prom, Await &&await) -> AsyncTask {
+    AsyncTask *taskPtr = new AsyncTask;
+    auto task = [taskPtr](std::promise<Result> prom, Await await) -> AsyncTask {
         try
         {
             if constexpr (std::is_void_v<Result>)
@@ -581,7 +650,9 @@ inline auto co_future(Await await) noexcept
         {
             prom.set_exception(std::current_exception());
         }
-    }(std::move(prom), std::move(await));
+        delete taskPtr;
+    };
+    *taskPtr = task(std::move(prom), std::move(await));
     return fut;
 }
 

--- a/lib/tests/CoroutineTest.cc
+++ b/lib/tests/CoroutineTest.cc
@@ -43,6 +43,18 @@ int main()
     // No, you cannot await AsyncTask. By design
     static_assert(is_awaitable_v<AsyncTask> == false);
 
+    int n = 0;
+    sync_wait([&]() -> Task<> {
+        n = 1;
+        co_return;
+    }());
+    if (n != 1)
+    {
+        std::cerr
+            << "Expected coroutine to change external valud. Didn't happen\n";
+        exit(1);
+    }
+
     // Make sure sync_wait works
     if (sync_wait([]() -> Task<int> { co_return 1; }()) != 1)
     {
@@ -50,13 +62,16 @@ int main()
         exit(1);
     }
 
-    // co_future converts coroutine into futures
-    auto fut = co_future([]() -> Task<std::string> { co_return "zxc"; }());
-    if (fut.get() != "zxc")
-    {
-        std::cerr << "Expected future return \'zxc\'. Didn't get that\n";
-        exit(1);
-    }
+    // co_future converts coroutine into futures. Doesn't work for now
+    //  as fut.get() waits for the coroutine. Yet the coroutine needs
+    //  the same thread to resume execution for it to return a value.
+    //  Thus causing a dead lock
+    // auto fut = co_future([]() -> Task<std::string> { co_return "zxc"; }());
+    // if (fut.get() != "zxc")
+    // {
+    //     std::cerr << "Expected future return \'zxc\'. Didn't get that\n";
+    //     exit(1);
+    // }
 
     // Testing that exceptions can propergate through coroutines
     auto throw_in_task = []() -> Task<> {


### PR DESCRIPTION
* Improve AsyncTask to always release their coroutine frame at the correct time
  * Fixes AsycnTask leak when outside of a event loop
* Fix sync_wait/co_future triggering Address Sanitizer's use-after-free detection
* sync_wait now spawns a new thread to avoid deadlock on the local thread

Tested on GCC11