### PR TITLE
Make AsyncTask only destruct when the coroutine reaches end of execution

### DIFF
--- a/examples/simple_example/api_v1_CoroTest.cc
+++ b/examples/simple_example/api_v1_CoroTest.cc
@@ -4,6 +4,11 @@ using namespace api::v1;
 Task<> CoroTest::get(HttpRequestPtr req,
                      std::function<void(const HttpResponsePtr &)> callback)
 {
+    // Force co_await to test awaiting works
+    co_await drogon::sleepCoro(
+        trantor::EventLoop::getEventLoopOfCurrentThread(),
+        std::chrono::milliseconds(100));
+
     auto resp = HttpResponse::newHttpResponse();
     resp->setBody("DEADBEEF");
     callback(resp);

--- a/examples/simple_example_test/WebSocketCoroTest.cc
+++ b/examples/simple_example_test/WebSocketCoroTest.cc
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
     });
     app().setLogLevel(trantor::Logger::kTrace);
 
-    auto test = [=]() -> AsyncTask {
+    [=]() -> AsyncTask {
         co_await doTest(wsPtr, req, continually);
     }();
 

--- a/examples/simple_example_test/WebSocketCoroTest.cc
+++ b/examples/simple_example_test/WebSocketCoroTest.cc
@@ -74,9 +74,7 @@ int main(int argc, char* argv[])
     });
     app().setLogLevel(trantor::Logger::kTrace);
 
-    [=]() -> AsyncTask {
-        co_await doTest(wsPtr, req, continually);
-    }();
+    [=]() -> AsyncTask { co_await doTest(wsPtr, req, continually); }();
 
     app().run();
 }

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -312,7 +312,6 @@ class HttpBinder : public HttpBinderBase
         std::function<void(const HttpResponsePtr &)> &&callback,
         Values &&... values)
     {
-        // auto taskPtr = new AsyncTask;
         [this](HttpRequestPtr req,
                std::function<void(const HttpResponsePtr &)> callback,
                Values &&... values) -> AsyncTask {

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -312,9 +312,10 @@ class HttpBinder : public HttpBinderBase
         std::function<void(const HttpResponsePtr &)> &&callback,
         Values &&... values)
     {
-        [this](HttpRequestPtr req,
+        auto taskPtr = std::make_shared<AsyncTask>();
+        *taskPtr = [taskPtr, this](HttpRequestPtr req,
                std::function<void(const HttpResponsePtr &)> callback,
-               Values &&... values) -> AsyncTask {
+               Values &&... values) mutable -> AsyncTask {
             try
             {
                 if constexpr (std::is_same_v<AsyncTask,
@@ -347,6 +348,7 @@ class HttpBinder : public HttpBinderBase
             {
                 LOG_ERROR << "Exception not derived from std::exception";
             }
+            taskPtr = nullptr;
         }(req, std::move(callback), std::move(values)...);
     }
 #endif

--- a/lib/inc/drogon/HttpBinder.h
+++ b/lib/inc/drogon/HttpBinder.h
@@ -312,10 +312,10 @@ class HttpBinder : public HttpBinderBase
         std::function<void(const HttpResponsePtr &)> &&callback,
         Values &&... values)
     {
-        auto taskPtr = std::make_shared<AsyncTask>();
-        *taskPtr = [taskPtr, this](HttpRequestPtr req,
+        // auto taskPtr = new AsyncTask;
+        [this](HttpRequestPtr req,
                std::function<void(const HttpResponsePtr &)> callback,
-               Values &&... values) mutable -> AsyncTask {
+               Values &&... values) -> AsyncTask {
             try
             {
                 if constexpr (std::is_same_v<AsyncTask,
@@ -348,7 +348,6 @@ class HttpBinder : public HttpBinderBase
             {
                 LOG_ERROR << "Exception not derived from std::exception";
             }
-            taskPtr = nullptr;
         }(req, std::move(callback), std::move(values)...);
     }
 #endif

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -396,7 +396,7 @@ struct AsyncTask
 
     AsyncTask(handle_type h) : coro_(h)
     {
-        if(coro_)
+        if (coro_)
             coro_.promise().setSelf(coro_);
     }
     AsyncTask(const AsyncTask &) = delete;
@@ -457,7 +457,8 @@ struct AsyncTask
             struct awaiter
             {
                 awaiter(handle_type h) : self_(h)
-                {}
+                {
+                }
 
                 bool await_ready() const noexcept
                 {
@@ -474,8 +475,10 @@ struct AsyncTask
                     auto coro = handle.promise().continuation_;
                     if (coro)
                         return coro;
-                    if(self_)
+                    if (self_)
+                    {
                         self_.destroy();
+                    }
 
                     return std::noop_coroutine();
                 }
@@ -644,8 +647,8 @@ inline auto co_future(Await await) noexcept
     std::promise<Result> prom;
     auto fut = prom.get_future();
     [](std::promise<Result> prom,
-                   Await await,
-                   std::future<AsyncTask *> selfFut) mutable -> AsyncTask {
+       Await await,
+       std::future<AsyncTask *> selfFut) mutable -> AsyncTask {
         try
         {
             if constexpr (std::is_void_v<Result>)
@@ -660,7 +663,6 @@ inline auto co_future(Await await) noexcept
         {
             prom.set_exception(std::current_exception());
         }
-
     }();
     return fut;
 }

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -452,10 +452,20 @@ struct AsyncTask
 
         auto final_suspend() const noexcept
         {
-            struct awaiter
+            struct awaiter final
             {
+
                 awaiter(handle_type h) : self_(h)
                 {
+                }
+
+                awaiter(const awaiter&) = delete;
+                awaiter &operator=(const awaiter &) = delete;
+
+                ~awaiter()
+                {
+                    if (self_)
+                        self_.destroy();
                 }
 
                 bool await_ready() const noexcept
@@ -473,10 +483,6 @@ struct AsyncTask
                     auto coro = handle.promise().continuation_;
                     if (coro)
                         return coro;
-                    if (self_)
-                    {
-                        self_.destroy();
-                    }
 
                     return std::noop_coroutine();
                 }

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -454,12 +454,11 @@ struct AsyncTask
         {
             struct awaiter final
             {
-
                 awaiter(handle_type h) : self_(h)
                 {
                 }
 
-                awaiter(const awaiter&) = delete;
+                awaiter(const awaiter &) = delete;
                 awaiter &operator=(const awaiter &) = delete;
 
                 ~awaiter()

--- a/lib/inc/drogon/utils/coroutine.h
+++ b/lib/inc/drogon/utils/coroutine.h
@@ -409,8 +409,6 @@ struct AsyncTask
     {
         if (std::addressof(other) == this)
             return *this;
-        if (coro_)
-            coro_.destroy();
 
         coro_ = other.coro_;
         other.coro_ = nullptr;


### PR DESCRIPTION
My last patch(#855) causes handlers with coroutines to crash and the unit tests didn't catch the bug. This is the fix. Sorry for the inconvenience.