### PR TITLE
change some #ifdef's to #if in db_test

### DIFF
--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -1919,13 +1919,13 @@ int main(int argc, char **argv)
     mysqlClient = DbClient::newMysqlClient(
         "host=localhost port=3306 user=root client_encoding=utf8mb4", 1);
 #endif
-#ifdef USE_POSTGRESQL
+#if USE_POSTGRESQL
     postgreClient = DbClient::newPgClient(
         "host=127.0.0.1 port=5432 dbname=postgres user=postgres password=12345 "
         "client_encoding=utf8",
         1);
 #endif
-#ifdef USE_SQLITE3
+#if USE_SQLITE3
     sqlite3Client = DbClient::newSqlite3Client("filename=:memory:", 1);
 #endif
 
@@ -1936,10 +1936,10 @@ int main(int argc, char **argv)
 #if USE_MYSQL
     mysqlClient.reset();
 #endif
-#ifdef USE_POSTGRESQL
+#if USE_POSTGRESQL
     postgreClient.reset();
 #endif
-#ifdef USE_SQLITE3
+#if USE_SQLITE3
     sqlite3Client.reset();
 #endif
 


### PR DESCRIPTION
This PR fixes compile errors with new testing framework where `#ifdef` is inappropriate.  Below is part of my `drogon/config.h` after the cmakedefine's get configured.   To discern the presence of the databases, we need to use `#if` and not `#ifdef`.  

For example, `#ifdef USE_POSTGRESQL` is true and incorrect below, whereas `#if USE_POSTGRESQL` is false and correct.

```
#define USE_POSTGRESQL 0
#define USE_MYSQL 0
#define USE_SQLITE3 1
```

