### PR TITLE
Improve WebSocket mask handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (BUILD_DROGON_SHARED)
         SOVERSION ${DROGON_MAJOR_VERSION})
     target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
     if (WIN32)
-        target_link_libraries(${PROJECT_NAME} PUBLIC Rpcrt4 ws2_32)
+        target_link_libraries(${PROJECT_NAME} PUBLIC Rpcrt4 ws2_32 crypt32)
         if (CMAKE_CXX_COMPILER_ID MATCHES MSVC)
             # Ignore MSVC C4251 and C4275 warning of exporting std objects with no dll export
             # We export class to facilitate maintenance, thus if you compile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (BUILD_DROGON_SHARED)
         SOVERSION ${DROGON_MAJOR_VERSION})
     target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
     if (WIN32)
-        target_link_libraries(${PROJECT_NAME} PUBLIC Rpcrt4 ws2_32 crypt32)
+        target_link_libraries(${PROJECT_NAME} PUBLIC Rpcrt4 ws2_32 Advapi32)
         if (CMAKE_CXX_COMPILER_ID MATCHES MSVC)
             # Ignore MSVC C4251 and C4275 warning of exporting std objects with no dll export
             # We export class to facilitate maintenance, thus if you compile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (BUILD_DROGON_SHARED)
         SOVERSION ${DROGON_MAJOR_VERSION})
     target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
     if (WIN32)
-        target_link_libraries(${PROJECT_NAME} PUBLIC Rpcrt4 ws2_32 Advapi32)
+        target_link_libraries(${PROJECT_NAME} PUBLIC Rpcrt4 ws2_32 crypt32 Advapi32)
         if (CMAKE_CXX_COMPILER_ID MATCHES MSVC)
             # Ignore MSVC C4251 and C4275 warning of exporting std objects with no dll export
             # We export class to facilitate maintenance, thus if you compile

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -171,7 +171,7 @@ DROGON_EXPORT void replaceAll(std::string &s,
  *
  * @return true if generation is successfull. False otherwise
  *
- * @note DO NOT abuse this function. Espically if Drogon is built without
+ * @note DO NOT abuse this function. Especially if Drogon is built without
  * OpenSSL. Entropy running low is a real issue.
  */
 DROGON_EXPORT bool secureRandomBytes(void *ptr, size_t size);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -171,7 +171,7 @@ DROGON_EXPORT void replaceAll(std::string &s,
  *
  * @return true if generation is successfull. False otherwise
  *
- * @note DO NOT abuse this function. Espically is Drogon is built without
+ * @note DO NOT abuse this function. Espically if Drogon is built without
  * OpenSSL. Entropy running low is a real issue.
  */
 DROGON_EXPORT bool secureRandomBytes(void *ptr, size_t size);

--- a/lib/inc/drogon/utils/Utilities.h
+++ b/lib/inc/drogon/utils/Utilities.h
@@ -163,5 +163,18 @@ DROGON_EXPORT void replaceAll(std::string &s,
                               const std::string &from,
                               const std::string &to);
 
+/**
+ * @brief Generates cryptographically secure random bytes.
+ *
+ * @param ptr the pointer which the random bytes are stored to
+ * @param size number of bytes to generate
+ *
+ * @return true if generation is successfull. False otherwise
+ *
+ * @note DO NOT abuse this function. Espically is Drogon is built without
+ * OpenSSL. Entropy running low is a real issue.
+ */
+DROGON_EXPORT bool secureRandomBytes(void *ptr, size_t size);
+
 }  // namespace utils
 }  // namespace drogon

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -29,6 +29,7 @@
 #include <Rpc.h>
 #include <direct.h>
 #include <io.h>
+#include <Wincrypt.h>
 #else
 #include <uuid.h>
 #endif
@@ -47,7 +48,6 @@
 #include <string.h>
 #ifndef _WIN32
 #include <unistd.h>
-#include <Wincrypt.h>
 #endif
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1220,7 +1220,7 @@ static bool systemRandomBytes(void *ptr, size_t size)
     }
     if (fread(ptr, size, 1, fptr.get()) != 0)
         return true;
-#elif defined(_WIN32) // Windows
+#elif defined(_WIN32)  // Windows
     auto createCryptContext = []() {
         HCRYPTPROV *pProvider = new HCRYPTPROV;
         if (!CryptAcquireContextW(pProvider,
@@ -1236,11 +1236,11 @@ static bool systemRandomBytes(void *ptr, size_t size)
         return pProvider;
     };
     static std::unique_ptr<HCRYPTPROV, std::function<void(HCRYPTPROV *)>>
-            cryptCtxPtr(createCryptContext(), [](HCRYPTPROV *ptr) {
+        cryptCtxPtr(createCryptContext(), [](HCRYPTPROV *ptr) {
             CryptReleaseContext(*ptr, 0);
             delete ptr;
         });
-    if (CryptGenRandom(*cryptCtxPtr, size, (BYTE*) ptr))
+    if (CryptGenRandom(*cryptCtxPtr, size, (BYTE *)ptr))
         return true;
 #endif
     return false;
@@ -1259,4 +1259,3 @@ bool secureRandomBytes(void *ptr, size_t size)
 
 }  // namespace utils
 }  // namespace drogon
-

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1212,10 +1212,10 @@ static bool systemRandomBytes(void *ptr, size_t size)
     return true;
 #elif defined(__linux__)
     return getentropy(ptr, size) == 0;
-#elif defined(_WIN32)  // Windows
+#elif defined(_WIN32)    // Windows
     return RtlGenRandom(ptr, size);
-#elif defined(__unix__) // fallback to /dev/urandom for other UNIX
-    static std::unique_ptr<FILE, std::function<void(FILE *)>> fptr(
+#elif defined(__unix__)  // fallback to /dev/urandom for other UNIX
+    static std::unique_ptr<FILE, std::function<void(FILE *)> > fptr(
         fopen("/dev/urandom", "rb"), [](FILE *ptr) {
             if (ptr != nullptr)
                 fclose(ptr);

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -47,6 +47,7 @@
 #include <string.h>
 #ifndef _WIN32
 #include <unistd.h>
+#include <Wincrypt.h>
 #endif
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -1219,7 +1220,7 @@ static bool systemRandomBytes(void *ptr, size_t size)
     }
     if (fread(ptr, size, 1, fptr.get()) != 0)
         return true;
-#else  // Windows
+#elif defined(_WIN32) // Windows
     auto createCryptContext =
         []() {
             HCRYPTPROV hProvider = 0;

--- a/lib/src/Utilities.cc
+++ b/lib/src/Utilities.cc
@@ -1218,7 +1218,7 @@ static bool systemRandomBytes(void *ptr, size_t size)
         LOG_FATAL << "Failed to open /dev/urandom for randomness";
         abort();
     }
-    if (fread(ptr, size, 1, fptr.get()) != 0)
+    if (fread(ptr, 1, size, fptr.get()) != 0)
         return true;
 #elif defined(_WIN32)  // Windows
     auto createCryptContext = []() {

--- a/lib/src/WebSocketConnectionImpl.cc
+++ b/lib/src/WebSocketConnectionImpl.cc
@@ -114,10 +114,13 @@ void WebSocketConnectionImpl::sendWsData(const char *msg,
             if (masks_.empty())
             {
                 masks_.resize(16);
-                bool status = utils::secureRandomBytes(masks_.data(), masks_.size()*sizeof(uint32_t));
+                bool status =
+                    utils::secureRandomBytes(masks_.data(),
+                                             masks_.size() * sizeof(uint32_t));
                 if (status == false)
                 {
-                    LOG_ERROR << "Failed to generate random numbers for WebSocket mask";
+                    LOG_ERROR << "Failed to generate random numbers for "
+                                 "WebSocket mask";
                     abort();
                 }
             }
@@ -434,4 +437,3 @@ void WebSocketConnectionImpl::setPingMessageInLoop(
             }
         });
 }
-

--- a/lib/src/WebSocketConnectionImpl.cc
+++ b/lib/src/WebSocketConnectionImpl.cc
@@ -114,7 +114,7 @@ void WebSocketConnectionImpl::sendWsData(const char *msg,
 
         bytesFormatted[1] = (bytesFormatted[1] | 0x80);
         bytesFormatted.resize(indexStartRawData + 4 + len);
-        *((int *)&bytesFormatted[indexStartRawData]) = random;
+        memcpy(&bytesFormatted[indexStartRawData], &random, sizeof(random));
         for (size_t i = 0; i < len; ++i)
         {
             bytesFormatted[indexStartRawData + 4 + i] =

--- a/lib/src/WebSocketConnectionImpl.cc
+++ b/lib/src/WebSocketConnectionImpl.cc
@@ -114,7 +114,12 @@ void WebSocketConnectionImpl::sendWsData(const char *msg,
             if (masks_.empty())
             {
                 masks_.resize(16);
-                utils::secureRandomBytes(masks_.data(), masks_.size());
+                bool status = utils::secureRandomBytes(masks_.data(), masks_.size()*sizeof(uint32_t));
+                if (status == false)
+                {
+                    LOG_ERROR << "Failed to generate random numbers for WebSocket mask";
+                    abort();
+                }
             }
             random = masks_.back();
             masks_.pop_back();
@@ -122,7 +127,13 @@ void WebSocketConnectionImpl::sendWsData(const char *msg,
         }
         else
         {
-            utils::secureRandomBytes(&random, sizeof(random));
+            bool status = utils::secureRandomBytes(&random, sizeof(random));
+            if (status == false)
+            {
+                LOG_ERROR
+                    << "Failed to generate random numbers for WebSocket mask";
+                abort();
+            }
         }
 
         bytesFormatted[1] = (bytesFormatted[1] | 0x80);
@@ -423,3 +434,4 @@ void WebSocketConnectionImpl::setPingMessageInLoop(
             }
         });
 }
+

--- a/lib/src/WebSocketConnectionImpl.cc
+++ b/lib/src/WebSocketConnectionImpl.cc
@@ -23,7 +23,8 @@ WebSocketConnectionImpl::WebSocketConnectionImpl(
     : tcpConnectionPtr_(conn),
       localAddr_(conn->localAddr()),
       peerAddr_(conn->peerAddr()),
-      isServer_(isServer)
+      isServer_(isServer),
+      usingMask_(false)
 {
 }
 WebSocketConnectionImpl::~WebSocketConnectionImpl()
@@ -105,12 +106,24 @@ void WebSocketConnectionImpl::sendWsData(const char *msg,
     }
     if (!isServer_)
     {
-        // Add masking key;
-        static std::once_flag once;
-        std::call_once(once, []() {
-            std::srand(static_cast<unsigned int>(time(nullptr)));
-        });
-        int random = std::rand();
+        int random;
+        // Use the cached randomness if no one else is also using it. Otherwise
+        // generate one from scratch.
+        if (!usingMask_.exchange(true))
+        {
+            if (masks_.empty())
+            {
+                masks_.resize(16);
+                utils::secureRandomBytes(masks_.data(), masks_.size());
+            }
+            random = masks_.back();
+            masks_.pop_back();
+            usingMask_ = false;
+        }
+        else
+        {
+            utils::secureRandomBytes(&random, sizeof(random));
+        }
 
         bytesFormatted[1] = (bytesFormatted[1] | 0x80);
         bytesFormatted.resize(indexStartRawData + 4 + len);

--- a/lib/src/WebSocketConnectionImpl.h
+++ b/lib/src/WebSocketConnectionImpl.h
@@ -108,6 +108,8 @@ class WebSocketConnectionImpl final
     bool isServer_{true};
     WebSocketMessageParser parser_;
     trantor::TimerId pingTimerId_{trantor::InvalidTimerId};
+    std::vector<uint32_t> masks_;
+    std::atomic<bool> usingMask_;
 
     std::function<void(std::string &&,
                        const WebSocketConnectionImplPtr &,

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -1930,7 +1930,6 @@ int main(int argc, char **argv)
 #endif
 
     int testStatus = test::run(argc, argv);
-    std::this_thread::sleep_for(0.008s);
 
     // Destruct the clients before event loop shutdown
 #if USE_MYSQL
@@ -1942,6 +1941,7 @@ int main(int argc, char **argv)
 #ifdef USE_SQLITE3
     sqlite3Client.reset();
 #endif
+    std::this_thread::sleep_for(0.008s);
 
     return testStatus;
 }

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -1917,7 +1917,7 @@ int main(int argc, char **argv)
 
 #if USE_MYSQL
     mysqlClient = DbClient::newMysqlClient(
-        "host=localhost port=3306 user=root client_encoding=utf8mb4 password=marty1885", 1);
+        "host=localhost port=3306 user=root client_encoding=utf8mb4", 1);
 #endif
 #ifdef USE_POSTGRESQL
     postgreClient = DbClient::newPgClient(

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -1917,7 +1917,7 @@ int main(int argc, char **argv)
 
 #if USE_MYSQL
     mysqlClient = DbClient::newMysqlClient(
-        "host=localhost port=3306 user=root client_encoding=utf8mb4", 1);
+        "host=localhost port=3306 user=root client_encoding=utf8mb4 password=marty1885", 1);
 #endif
 #ifdef USE_POSTGRESQL
     postgreClient = DbClient::newPgClient(

--- a/orm_lib/tests/db_test.cc
+++ b/orm_lib/tests/db_test.cc
@@ -1931,17 +1931,5 @@ int main(int argc, char **argv)
 
     int testStatus = test::run(argc, argv);
 
-    // Destruct the clients before event loop shutdown
-#if USE_MYSQL
-    mysqlClient.reset();
-#endif
-#ifdef USE_POSTGRESQL
-    postgreClient.reset();
-#endif
-#ifdef USE_SQLITE3
-    sqlite3Client.reset();
-#endif
-    std::this_thread::sleep_for(0.008s);
-
     return testStatus;
 }

--- a/test.sh
+++ b/test.sh
@@ -176,7 +176,9 @@ if [ "$1" = "-t" ]; then
     if [ -f "./orm_lib/tests/db_test" ]; then
         echo "Test database"
         ./orm_lib/tests/db_test -s
-        if [ $? -ne 0 ]; then
+	#HACK: Workarround db_test crash on Ubuntu 16.04.
+	#      Assume crashed db_test is good.
+        if [ $? -ne 0 -a $? -ne 255 ]; then
             echo "Error in testing"
             exit -1
         fi

--- a/test.sh
+++ b/test.sh
@@ -178,7 +178,7 @@ if [ "$1" = "-t" ]; then
         ./orm_lib/tests/db_test -s
 	#HACK: Workarround db_test crash on Ubuntu 16.04.
 	#      Assume crashed db_test is good.
-        if [ $? -ne 0 -a $? -ne 255 ]; then
+        if [ $? -ne 0 -a $? -ne 134 ]; then
             echo "Error in testing"
             exit -1
         fi

--- a/test.sh
+++ b/test.sh
@@ -176,9 +176,7 @@ if [ "$1" = "-t" ]; then
     if [ -f "./orm_lib/tests/db_test" ]; then
         echo "Test database"
         ./orm_lib/tests/db_test -s
-	#HACK: Workarround db_test crash on Ubuntu 16.04.
-	#      Assume crashed db_test is good.
-        if [ $? -ne 0 -a $? -ne 134 ]; then
+        if [ $? -ne 0 ]; then
             echo "Error in testing"
             exit -1
         fi


### PR DESCRIPTION
The current WebSocket implementation triggers UBSan when applying the mask.

```
/home/marty/Documents/drogon/lib/src/WebSocketConnectionImpl.cc:117:9: runtime error: store to misaligned address 0x7fc50c008592 for type 'int', which requires 4 byte alignment
0x7fc50c008592: note: pointer points here
 00 00  81 86 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00
              ^ 
```

Also, currently we generate the mask from `std::rand()`. Which is not as strong as the RFC requires. (Besides it's LCG, `rand()` on [Windows is 15 bits](https://docs.microsoft.com/en-us/cpp/c-runtime-library/rand-max?view=msvc-160))

Quote from RFC 6455 section 10.3: 
```
   Clients MUST choose a new masking key for each frame, using an
   algorithm that cannot be predicted by end applications that provide
   data.  For example, each masking could be drawn from a
   cryptographically strong random number generator.
```

This patch provides three improvements

* Fix the 4 byte alignment issue
* Add API to take secure random numbers
* Uses cryptographically strong numbers for the mask
   * With a 16-elemnt cache, per-connection. 16 is a random number I came up with to not use too much memory for embedded systems users. But also large enough to not hammer the entropy source. Maybe we should change it?

It tries to generate numbers from OpenSSL if available. If not, it takes number from `/dev/urandom` (UNIX) or Cryptographic Services (Windows),
