### PR TITLE
Fix routing mismatch

### DIFF
--- a/lib/src/HttpControllersRouter.cc
+++ b/lib/src/HttpControllersRouter.cc
@@ -386,7 +386,7 @@ void HttpControllersRouter::addHttpPath(
         // Recreate this with the correct number of threads.
         binderInfo->responseCache_ = IOThreadStorage<HttpResponsePtr>();
     });
-    bool routingRequiresRegex = (path != pathParameterPattern);
+    bool routingRequiresRegex = (originPath != pathParameterPattern);
     HttpControllerRouterItem *existingRouterItemPtr = nullptr;
 
     // If exists another controllers on the same route. Updathe them then exit
@@ -401,8 +401,11 @@ void HttpControllersRouter::addHttpPath(
     else
     {
         std::string loweredPath;
-        loweredPath.resize(path.size());
-        std::transform(path.begin(), path.end(), loweredPath.begin(), tolower);
+        loweredPath.resize(originPath.size());
+        std::transform(originPath.begin(),
+                       originPath.end(),
+                       loweredPath.begin(),
+                       tolower);
         auto it = ctrlMap_.find(loweredPath);
         if (it != ctrlMap_.end())
             existingRouterItemPtr = &it->second;
@@ -453,8 +456,11 @@ void HttpControllersRouter::addHttpPath(
     else
     {
         std::string loweredPath;
-        loweredPath.resize(path.size());
-        std::transform(path.begin(), path.end(), loweredPath.begin(), tolower);
+        loweredPath.resize(originPath.size());
+        std::transform(originPath.begin(),
+                       originPath.end(),
+                       loweredPath.begin(),
+                       tolower);
         ctrlMap_[loweredPath] = std::move(router);
     }
 }

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(INTEGRATION_TEST_SERVER_SOURCES
     integration_test/server/api_v1_ApiTest.cc
     integration_test/server/TimeFilter.cc
     integration_test/server/DigestAuthFilter.cc
+    integration_test/server/MethodTest.cc
     integration_test/server/main.cc)
 
 if(DROGON_CXX_STANDARD GREATER_EQUAL 20 AND HAS_COROUTINE)

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -354,6 +354,73 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
                             CHECK(resp->getBody().length() == 4994);
                         });
 
+    /// Test method routing, see MethodTest.h
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Post);
+    req->setPath("/api/method/regex/drogon/test?test=drogon");
+    client->sendRequest(req,
+                        [req, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            auto jsonPtr = resp->getJsonObject();
+                            CHECK(jsonPtr);
+                            CHECK(jsonPtr->asString() == "POST");
+                        });
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/api/method/regex/drogon/test");
+    client->sendRequest(req,
+                        [req, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            auto jsonPtr = resp->getJsonObject();
+                            CHECK(jsonPtr);
+                            CHECK(jsonPtr->asString() == "GET");
+                        });
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Post);
+    req->setPath("/api/method/drogon/test?test=drogon");
+    client->sendRequest(req,
+                        [req, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            auto jsonPtr = resp->getJsonObject();
+                            CHECK(jsonPtr);
+                            CHECK(jsonPtr->asString() == "POST");
+                        });
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/api/method/drogon/test");
+    client->sendRequest(req,
+                        [req, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            auto jsonPtr = resp->getJsonObject();
+                            CHECK(jsonPtr);
+                            CHECK(jsonPtr->asString() == "GET");
+                        });
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Post);
+    req->setPath("/api/method/test?test=drogon");
+    client->sendRequest(req,
+                        [req, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            auto jsonPtr = resp->getJsonObject();
+                            CHECK(jsonPtr);
+                            CHECK(jsonPtr->asString() == "POST");
+                        });
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/api/method/test");
+    client->sendRequest(req,
+                        [req, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            auto jsonPtr = resp->getJsonObject();
+                            CHECK(jsonPtr);
+                            CHECK(jsonPtr->asString() == "GET");
+                        });
     /// Test static function
     req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);

--- a/lib/tests/integration_test/server/MethodTest.cc
+++ b/lib/tests/integration_test/server/MethodTest.cc
@@ -1,0 +1,53 @@
+#include "MethodTest.h"
+static void makeGetRespose(
+    const std::function<void(const HttpResponsePtr &)> &callback)
+{
+    callback(drogon::HttpResponse::newHttpJsonResponse("GET"));
+}
+
+static void makePostRespose(
+    const std::function<void(const HttpResponsePtr &)> &callback)
+{
+    callback(drogon::HttpResponse::newHttpJsonResponse("POST"));
+}
+
+void MethodTest::get(const HttpRequestPtr &req,
+                     std::function<void(const HttpResponsePtr &)> &&callback)
+{
+    LOG_DEBUG;
+    makeGetRespose(callback);
+}
+void MethodTest::post(const HttpRequestPtr &req,
+                      std::function<void(const HttpResponsePtr &)> &&callback,
+                      std::string str)
+{
+    LOG_DEBUG << str;
+    makePostRespose(callback);
+}
+
+void MethodTest::getReg(const HttpRequestPtr &req,
+                        std::function<void(const HttpResponsePtr &)> &&callback,
+                        std::string regStr)
+{
+    LOG_DEBUG << regStr;
+    makeGetRespose(callback);
+}
+void MethodTest::postReg(
+    const HttpRequestPtr &req,
+    std::function<void(const HttpResponsePtr &)> &&callback,
+    std::string regStr,
+    std::string str)
+{
+    LOG_DEBUG << regStr;
+    LOG_DEBUG << str;
+    makePostRespose(callback);
+}
+
+void MethodTest::postRegex(
+    const HttpRequestPtr &req,
+    std::function<void(const HttpResponsePtr &)> &&callback,
+    std::string regStr)
+{
+    LOG_DEBUG << regStr;
+    makePostRespose(callback);
+}

--- a/lib/tests/integration_test/server/MethodTest.h
+++ b/lib/tests/integration_test/server/MethodTest.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <drogon/HttpController.h>
+using namespace drogon;
+class MethodTest : public drogon::HttpController<MethodTest>
+{
+  public:
+    METHOD_LIST_BEGIN
+    ADD_METHOD_TO(MethodTest::get, "/api/method/test", Get);
+    ADD_METHOD_TO(MethodTest::post, "/api/method/test?test={}", Post);
+    ADD_METHOD_TO(MethodTest::getReg, "/api/method/{}/test", Get);
+    ADD_METHOD_TO(MethodTest::postReg, "/api/method/{}/test?test={}", Post);
+    ADD_METHOD_VIA_REGEX(MethodTest::getReg,
+                         "/api/method/regex/(.*)/test",
+                         Get);
+    ADD_METHOD_VIA_REGEX(MethodTest::postRegex,
+                         "/api/method/regex/(.*)/test",
+                         Post);
+    METHOD_LIST_END
+
+    void get(const HttpRequestPtr &req,
+             std::function<void(const HttpResponsePtr &)> &&callback);
+    void post(const HttpRequestPtr &req,
+              std::function<void(const HttpResponsePtr &)> &&callback,
+              std::string str);
+
+    void getReg(const HttpRequestPtr &req,
+                std::function<void(const HttpResponsePtr &)> &&callback,
+                std::string regStr);
+    void postReg(const HttpRequestPtr &req,
+                 std::function<void(const HttpResponsePtr &)> &&callback,
+                 std::string regStr,
+                 std::string str);
+    void postRegex(const HttpRequestPtr &req,
+                   std::function<void(const HttpResponsePtr &)> &&callback,
+                   std::string regStr);
+};


### PR DESCRIPTION
This PR is going to fix a mismatch error when router is set as follows:

```c++
    METHOD_LIST_BEGIN
    ADD_METHOD_TO(RTest::get, "/api/test", Get);
    ADD_METHOD_TO(RTest::post, "/api/test?level={}", Post);
    METHOD_LIST_END
```