### PR TITLE
Fix CacheMap crashing in unittest

### DIFF
--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -128,6 +128,7 @@ class CacheMap
     ~CacheMap()
     {
         map_.clear();
+        std::lock_guard<std::mutex> lock(bucketMutex_);
         for (auto iter = wheels_.rbegin(); iter != wheels_.rend(); ++iter)
         {
             iter->clear();

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -127,6 +127,7 @@ class CacheMap
     };
     ~CacheMap()
     {
+        loop_->invalidateTimer(timerId_);
         map_.clear();
         std::lock_guard<std::mutex> lock(bucketMutex_);
         for (auto iter = wheels_.rbegin(); iter != wheels_.rend(); ++iter)

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -129,7 +129,6 @@ class CacheMap
     {
         loop_->invalidateTimer(timerId_);
         map_.clear();
-        std::lock_guard<std::mutex> lock(bucketMutex_);
         for (auto iter = wheels_.rbegin(); iter != wheels_.rend(); ++iter)
         {
             iter->clear();


### PR DESCRIPTION
`loop_->runAfer` isn't canceled anywhere. Meaning the wheel turning function is still called on every tick. So if we have a short-living CacheMap and run it on a timer living longer than it is (the global timer, etc). The timer still attempts to turn the CacheMap every once in a while. But the CacheMap has been long gone. 

Hopefully we won't see tests crashing on CI again.

~~It is also possible for the CacheMap to destruct while timeout callback is active. This causes a very rare data race. And it's my hypothesis that this is the reason behind CacheMap crashes on CI. This patch locks the wheels upon destructing.~~ (The fix deadlocks, I don't know why. This should be really rare, though)

