### PR TITLE
Fix CacheMap crash in CI tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,7 @@
 version: 1.6.0.{build}
 configuration:
 - Release
+- Debug
 
 environment:
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,10 +23,12 @@ install:
 - vcpkg install jsoncpp:x64-windows
 - vcpkg install zlib:x86-windows
 - vcpkg install zlib:x64-windows
-- vcpkg install libpq:x86-windows
-- vcpkg install libpq:x64-windows
-- vcpkg install openssl:x86-windows
-- vcpkg install openssl:x64-windows
+- vcpkg install sqlite3:x86-windows
+- vcpkg install sqlite3:x64-windows
+#- vcpkg install libpq:x86-windows
+#- vcpkg install libpq:x64-windows
+#- vcpkg install openssl:x86-windows
+#- vcpkg install openssl:x64-windows
 - vcpkg integrate install
 - cd %APPVEYOR_BUILD_FOLDER%
 before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 version: 1.6.0.{build}
 configuration:
 - Release
-- Debug
 
 environment:
   matrix:
@@ -23,12 +22,8 @@ install:
 - vcpkg install jsoncpp:x64-windows
 - vcpkg install zlib:x86-windows
 - vcpkg install zlib:x64-windows
-- vcpkg install sqlite3:x86-windows
-- vcpkg install sqlite3:x64-windows
-#- vcpkg install libpq:x86-windows
-#- vcpkg install libpq:x64-windows
-#- vcpkg install openssl:x86-windows
-#- vcpkg install openssl:x64-windows
+- vcpkg install libpq:x86-windows
+- vcpkg install libpq:x64-windows
 - vcpkg integrate install
 - cd %APPVEYOR_BUILD_FOLDER%
 before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,8 @@ install:
 - vcpkg install zlib:x64-windows
 - vcpkg install libpq:x86-windows
 - vcpkg install libpq:x64-windows
+- vcpkg install openssl:x86-windows
+- vcpkg install openssl:x64-windows
 - vcpkg integrate install
 - cd %APPVEYOR_BUILD_FOLDER%
 before_build:

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -90,8 +90,8 @@ class CacheMap
         : loop_(loop),
           tickInterval_(tickInterval),
           wheelsNumber_(wheelsNum),
-          bucketsNumPerWheel_(bucketsNumPerWheel),
-          ctrlBlockPtr_(std::make_shared<ControlBlock>())
+          ctrlBlockPtr_(std::make_shared<ControlBlock>()),
+          bucketsNumPerWheel_(bucketsNumPerWheel)
     {
         wheels_.resize(wheelsNumber_);
         for (size_t i = 0; i < wheelsNumber_; ++i)

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -137,8 +137,8 @@ class CacheMap
     };
     ~CacheMap()
     {
-        ctrlBlockPtr_->destructed = true;
         std::lock_guard<std::mutex> lock(ctrlBlockPtr_->mtx);
+        ctrlBlockPtr_->destructed = true;
         map_.clear();
         if (!ctrlBlockPtr_->loopEnded)
         {
@@ -406,8 +406,8 @@ class CacheMap
         ControlBlock() : destructed(false), loopEnded(false)
         {
         }
-        std::atomic<bool> destructed;
-        std::atomic<bool> loopEnded;
+        bool destructed;
+        bool loopEnded;
         std::mutex mtx;
     };
     std::unordered_map<T1, MapValue> map_;

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -138,8 +138,8 @@ class CacheMap
     ~CacheMap()
     {
         ctrlBlockPtr_->destructed = true;
-        map_.clear();
         std::lock_guard<std::mutex> lock(ctrlBlockPtr_->mtx);
+        map_.clear();
         if (!ctrlBlockPtr_->loopEnded)
         {
             loop_->invalidateTimer(timerId_);

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -137,7 +137,6 @@ class CacheMap
     ~CacheMap()
     {
         *destructed_ = true;
-        loop_->invalidateTimer(timerId_);
         map_.clear();
         std::lock_guard<std::mutex> lock(bucketQueueMutex_);
         for (auto iter = wheels_.rbegin(); iter != wheels_.rend(); ++iter)

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -101,9 +101,7 @@ class CacheMap
         if (tickInterval_ > 0 && wheelsNumber_ > 0 && bucketsNumPerWheel_ > 0)
         {
             timerId_ = loop_->runEvery(
-                tickInterval_,
-                [this, ctrlBlockPtr = ctrlBlockPtr_]()
-                {
+                tickInterval_, [this, ctrlBlockPtr = ctrlBlockPtr_]() {
                     // 2-phase check to ensure the CacheMap didn't destruct
                     // after the 1st check and before the mutex
                     if (ctrlBlockPtr->destructed)
@@ -131,12 +129,10 @@ class CacheMap
                         pow = pow * bucketsNumPerWheel_;
                     }
                 });
-            loop_->runOnQuit(
-                [ctrlBlockPtr = ctrlBlockPtr_]
-                {
-                    std::lock_guard<std::mutex> lock(ctrlBlockPtr->mtx);
-                    ctrlBlockPtr->loopEnded = true;
-                });
+            loop_->runOnQuit([ctrlBlockPtr = ctrlBlockPtr_] {
+                std::lock_guard<std::mutex> lock(ctrlBlockPtr->mtx);
+                ctrlBlockPtr->loopEnded = true;
+            });
         }
         else
         {
@@ -453,8 +449,7 @@ class CacheMap
             if (i < (wheelsNumber_ - 1))
             {
                 entryPtr = std::make_shared<CallbackEntry>(
-                    [this, delay, i, t, entryPtr]()
-                    {
+                    [this, delay, i, t, entryPtr]() {
                         if (delay > 0)
                         {
                             std::lock_guard<std::mutex> lock(bucketMutex_);
@@ -494,8 +489,7 @@ class CacheMap
         }
         else
         {
-            std::function<void()> cb = [this, key]()
-            {
+            std::function<void()> cb = [this, key]() {
                 std::lock_guard<std::mutex> lock(mtx_);
                 if (map_.find(key) != map_.end())
                 {

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -128,6 +128,7 @@ class CacheMap
     ~CacheMap()
     {
         map_.clear();
+        std::lock_guard<std::mutex> lock(bucketMutex_);
         for (auto iter = wheels_.rbegin(); iter != wheels_.rend(); ++iter)
         {
             iter->clear();

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -90,8 +90,8 @@ class CacheMap
         : loop_(loop),
           tickInterval_(tickInterval),
           wheelsNumber_(wheelsNum),
-          ctrlBlockPtr_(std::make_shared<ControlBlock>()),
-          bucketsNumPerWheel_(bucketsNumPerWheel)
+          bucketsNumPerWheel_(bucketsNumPerWheel),
+          ctrlBlockPtr_(std::make_shared<ControlBlock>())
     {
         wheels_.resize(wheelsNumber_);
         for (size_t i = 0; i < wheelsNumber_; ++i)
@@ -428,11 +428,11 @@ class CacheMap
     std::mutex bucketMutex_;
     trantor::TimerId timerId_;
     trantor::EventLoop *loop_;
-    std::shared_ptr<ControlBlock> ctrlBlockPtr_;
 
     float tickInterval_;
     size_t wheelsNumber_;
     size_t bucketsNumPerWheel_;
+    std::shared_ptr<ControlBlock> ctrlBlockPtr_;
 
     bool noWheels_{false};
 

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -102,10 +102,6 @@ class CacheMap
         {
             timerId_ = loop_->runEvery(
                 tickInterval_, [this, ctrlBlockPtr = ctrlBlockPtr_]() {
-                    // 2-phase check to ensure the CacheMap didn't destruct
-                    // after the 1st check and before the mutex
-                    if (ctrlBlockPtr->destructed)
-                        return;
                     std::lock_guard<std::mutex> lock(ctrlBlockPtr->mtx);
                     if (ctrlBlockPtr->destructed)
                         return;

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -127,6 +127,7 @@ class CacheMap
     };
     ~CacheMap()
     {
+        loop_->invalidateTimer(timerId_);
         map_.clear();
         std::lock_guard<std::mutex> lock(bucketMutex_);
         for (auto iter = wheels_.rbegin(); iter != wheels_.rend(); ++iter)

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -129,7 +129,6 @@ class CacheMap
     {
         loop_->invalidateTimer(timerId_);
         map_.clear();
-        std::lock_guard<std::mutex> lock(bucketMutex_);
         for (auto iter = wheels_.rbegin(); iter != wheels_.rend(); ++iter)
         {
             iter->clear();

--- a/lib/inc/drogon/CacheMap.h
+++ b/lib/inc/drogon/CacheMap.h
@@ -102,6 +102,7 @@ class CacheMap
             timerId_ = loop_->runEvery(tickInterval_, [this]() {
                 size_t t = ++ticksCounter_;
                 size_t pow = 1;
+                std::lock_guard<std::mutex> lock(bucketQueueMutex_);
                 for (size_t i = 0; i < wheelsNumber_; ++i)
                 {
                     if ((t % pow) == 0)
@@ -129,6 +130,7 @@ class CacheMap
     {
         loop_->invalidateTimer(timerId_);
         map_.clear();
+        std::lock_guard<std::mutex> lock(bucketQueueMutex_);
         for (auto iter = wheels_.rbegin(); iter != wheels_.rend(); ++iter)
         {
             iter->clear();
@@ -385,6 +387,7 @@ class CacheMap
 
     std::mutex mtx_;
     std::mutex bucketMutex_;
+    std::mutex bucketQueueMutex_;
     trantor::TimerId timerId_;
     trantor::EventLoop *loop_;
 

--- a/lib/tests/unittests/CacheMapTest.cc
+++ b/lib/tests/unittests/CacheMapTest.cc
@@ -36,6 +36,4 @@ DROGON_TEST(CacheMapTest)
     std::string content;
     cache.findAndFetch("zzz", content);
     CHECK(content == "-");
-
-    loopThread.getLoop()->quit();
 }


### PR DESCRIPTION
There are 2 bugs in CacheMap that leads to a crash. This patch fixes them

1. The wheel turning timer is never disabled, even upon destruction.
2. The wheel turning function can be executing while destructing. 

The first bug leads to this PoC crashing

```c++
void foo(trantor::EventLoop* loop)
{
	CacheMap<std::string, std::string> cache(loop, 0.1, 4, 20);
}

int main()
{
	trantor::EventLoopThread thr;
	thr.run();
	foo(thr.getLoop());
	std::this_thread::sleep_for(std::chrono::seconds(20));
	// Segfault because event loop tries to tick on the CacheMap. But it already de-allocated
}
```

The second bug is more subtle. If it just happens that the tick triggers while destructing, then it crashes due the destructor and the tick function both reads and modifies to the buckets.