### PR TITLE
Fix single layer directory traversal in StaticFileRouter

### DIFF
--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -59,11 +59,28 @@ void StaticFileRouter::route(
     std::function<void(const HttpResponsePtr &)> &&callback)
 {
     const std::string &path = req->path();
-    if (path.find("/../") != std::string::npos)
+    if(path.find("..") != std::string::npos)
     {
-        // Downloading files from the parent folder is forbidden.
-        callback(app().getCustomErrorHandler()(k403Forbidden));
-        return;
+        auto directories = utils::splitString(path, "/");
+        int traversalDepth = 0;
+        for(const auto& dir : directories)
+        {
+            if(dir == "..")
+            {
+                traversalDepth--;
+            }
+            else
+            {
+                traversalDepth++;
+            }
+
+            if(traversalDepth < 0)
+            {
+                // Downloading files from the parent folder is forbidden.
+                callback(app().getCustomErrorHandler()(k403Forbidden));
+                return;
+            }
+        }
     }
 
     auto lPath = path;

--- a/lib/src/StaticFileRouter.cc
+++ b/lib/src/StaticFileRouter.cc
@@ -59,22 +59,22 @@ void StaticFileRouter::route(
     std::function<void(const HttpResponsePtr &)> &&callback)
 {
     const std::string &path = req->path();
-    if(path.find("..") != std::string::npos)
+    if (path.find("..") != std::string::npos)
     {
         auto directories = utils::splitString(path, "/");
         int traversalDepth = 0;
-        for(const auto& dir : directories)
+        for (const auto &dir : directories)
         {
-            if(dir == "..")
+            if (dir == "..")
             {
                 traversalDepth--;
             }
-            else
+            else if (dir != ".")
             {
                 traversalDepth++;
             }
 
-            if(traversalDepth < 0)
+            if (traversalDepth < 0)
             {
                 // Downloading files from the parent folder is forbidden.
                 callback(app().getCustomErrorHandler()(k403Forbidden));

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -681,7 +681,8 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
                             CHECK((*json)["P2"] == "test");
                         });
 
-    // Using .. to access a upper directory should be permitted as long as it never leaves the document root
+    // Using .. to access a upper directory should be permitted as long as
+    // it never leaves the document root
     req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);
     req->setPath("/a-directory/../index.html");

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -696,7 +696,7 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
     // . (current directory) shall also be allowed
     req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);
-    req->setPath("/a-directory./page.html");
+    req->setPath("/a-directory/page.html");
     client->sendRequest(req,
                         [req, TEST_CTX, body](ReqResult result,
                                               const HttpResponsePtr &resp) {

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -696,7 +696,7 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
     // . (current directory) shall also be allowed
     req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);
-    req->setPath("/a-directory/page.html");
+    req->setPath("/a-directory/./page.html");
     client->sendRequest(req,
                         [req, TEST_CTX, body](ReqResult result,
                                               const HttpResponsePtr &resp) {

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -692,7 +692,7 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
                             REQUIRE(result == ReqResult::Ok);
                             CHECK(resp->getBody().length() == indexLen);
                         });
-    
+
     // . (current directory) shall also be allowed
     req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);

--- a/lib/tests/integration_test/client/main.cc
+++ b/lib/tests/integration_test/client/main.cc
@@ -681,6 +681,31 @@ void doTest(const HttpClientPtr &client, std::shared_ptr<test::Case> TEST_CTX)
                             CHECK((*json)["P2"] == "test");
                         });
 
+    // Using .. to access a upper directory should be permitted as long as it never leaves the document root
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/a-directory/../index.html");
+    client->sendRequest(req,
+                        [req, TEST_CTX](ReqResult result,
+                                        const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            CHECK(resp->getBody().length() == indexLen);
+                        });
+    
+    // . (current directory) shall also be allowed
+    req = HttpRequest::newHttpRequest();
+    req->setMethod(drogon::Get);
+    req->setPath("/a-directory./page.html");
+    client->sendRequest(req,
+                        [req, TEST_CTX, body](ReqResult result,
+                                              const HttpResponsePtr &resp) {
+                            REQUIRE(result == ReqResult::Ok);
+                            CHECK(resp->getBody().length() == indexImplicitLen);
+                            CHECK(std::equal(body->begin(),
+                                             body->end(),
+                                             resp->getBody().begin()));
+                        });
+
     // Test exception handling
     req = HttpRequest::newHttpRequest();
     req->setMethod(drogon::Get);


### PR DESCRIPTION
The StaticFileRouter can access file in the immediate parent directory if the client sends a specially crafted, non RFC conforming HTTP 1.x request. By sending a HTTP request without a "/" predicating the path. The StaticFileRouter fails to detect directory traversal since [it checks for "/../" in the path](https://github.com/an-tao/drogon/blob/6a882841f1af2f7afd967a1cd1464915eab491d6/lib/src/StaticFileRouter.cc#L62).

The bug can only be triggered by a non RFC conforming client. For example sending a request through netcat.
![image](https://user-images.githubusercontent.com/8792393/123114671-10e90900-d472-11eb-91cd-1aaf434b981f.png)

This PR fixes the issue by detecting if there's potential for directory traversal. If true, we follow the path and detect if it reaches out of the document root at any point. Also added 2 new tests for edge cases in static file serving. (Not related to the bug).

Thanks for @oToToT finding this bug. Credits for discovering and locating the root cause goes to him.