### PR TITLE
fix clang-format 12 putting {} of a lambda body on the next line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,6 +36,7 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
+  AfterCaseLabel: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false

--- a/.clang-format
+++ b/.clang-format
@@ -21,23 +21,23 @@ AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false 
 BraceWrapping:   
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true


### PR DESCRIPTION
clang-format 12 comes with a new BeforeLambdaBody. Which is setted to
true due to BreakBeforeBraces being `Allman` in our config. Leading to
all lambdas being re-formatted since we put curly braces as the same
line as the lambda.

In short:

clang-format 11 (and before)

```c++
some_func([](){ /* It's fine!*/ });
```

clang-format 12

```c++
some_func([]()
{
    // Yeah...
});
```

This PR hopefully fixes it. But I can't tell since I only have the latest one.