### PR TITLE
Add GCC-compatible warnings to the example executables

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,9 +34,11 @@ set(example_targets
 
 # Add warnings for our example targets--some warnings (such as -Wunused-parameter) only appear
 # when the templated functions are instantiated at their point of use.
-foreach( target ${example_targets} )
-    target_compile_options(${target} PRIVATE -Wall -Wextra -Werror)
-endforeach()
+if (CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    foreach(target ${example_targets})
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Werror)
+    endforeach()
+endif()
 
 set_property(TARGET ${example_targets}
              PROPERTY CXX_STANDARD ${DROGON_CXX_STANDARD})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,6 +32,12 @@ set(example_targets
     login_session
     jsonstore)
 
+# Add warnings for our example targets--some warnings (such as -Wunused-parameter) only appear
+# when the templated functions are instantiated at their point of use.
+foreach( target ${example_targets} )
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Werror)
+endforeach()
+
 set_property(TARGET ${example_targets}
              PROPERTY CXX_STANDARD ${DROGON_CXX_STANDARD})
 set_property(TARGET ${example_targets} PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/examples/benchmark/BenchmarkCtrl.cc
+++ b/examples/benchmark/BenchmarkCtrl.cc
@@ -1,6 +1,6 @@
 #include "BenchmarkCtrl.h"
 void BenchmarkCtrl::asyncHandleHttpRequest(
-    const HttpRequestPtr &req,
+    const HttpRequestPtr &,
     std::function<void(const HttpResponsePtr &)> &&callback)
 {
     // write your application logic here

--- a/examples/benchmark/JsonCtrl.cc
+++ b/examples/benchmark/JsonCtrl.cc
@@ -1,6 +1,6 @@
 #include "JsonCtrl.h"
 void JsonCtrl::asyncHandleHttpRequest(
-    const HttpRequestPtr &req,
+    const HttpRequestPtr &,
     std::function<void(const HttpResponsePtr &)> &&callback)
 {
     Json::Value ret;

--- a/examples/client_example/main.cc
+++ b/examples/client_example/main.cc
@@ -20,7 +20,7 @@ int main()
         for (int i = 0; i < 10; ++i)
         {
             client->sendRequest(
-                req, [](ReqResult result, const HttpResponsePtr &response) {
+                req, [](ReqResult, const HttpResponsePtr &response) {
                     std::cout << "receive response!" << std::endl;
                     // auto headers=response.
                     ++nth_resp;

--- a/examples/file_upload/file_upload.cc
+++ b/examples/file_upload/file_upload.cc
@@ -5,7 +5,7 @@ int main()
 {
     app().registerHandler(
         "/",
-        [](const HttpRequestPtr &req,
+        [](const HttpRequestPtr &,
            std::function<void(const HttpResponsePtr &)> &&callback) {
             auto resp = HttpResponse::newHttpViewResponse("FileUpload");
             callback(resp);

--- a/examples/helloworld/HelloController.cc
+++ b/examples/helloworld/HelloController.cc
@@ -18,7 +18,7 @@ class SayHello : public HttpController<SayHello>
     METHOD_LIST_END
 
   protected:
-    void genericHello(const HttpRequestPtr &req,
+    void genericHello(const HttpRequestPtr &,
                       std::function<void(const HttpResponsePtr &)> &&callback)
     {
         auto resp = HttpResponse::newHttpResponse();
@@ -29,7 +29,7 @@ class SayHello : public HttpController<SayHello>
     }
 
     void personalizedHello(
-        const HttpRequestPtr &req,
+        const HttpRequestPtr &,
         std::function<void(const HttpResponsePtr &)> &&callback)
     {
         auto resp = HttpResponse::newHttpResponse();

--- a/examples/helloworld/main.cc
+++ b/examples/helloworld/main.cc
@@ -8,7 +8,7 @@ int main()
     // sent to Drogon
     app().registerHandler(
         "/",
-        [](const HttpRequestPtr &req,
+        [](const HttpRequestPtr &,
            std::function<void(const HttpResponsePtr &)> &&callback) {
             auto resp = HttpResponse::newHttpResponse();
             resp->setBody("Hello, World!");
@@ -23,7 +23,7 @@ int main()
     // for users to recognize the function of each parameter.
     app().registerHandler(
         "/user/{user-name}",
-        [](const HttpRequestPtr &req,
+        [](const HttpRequestPtr &,
            std::function<void(const HttpResponsePtr &)> &&callback,
            const std::string &name) {
             auto resp = HttpResponse::newHttpResponse();
@@ -36,7 +36,7 @@ int main()
     // URL!
     app().registerHandler(
         "/hello?user={user-name}",
-        [](const HttpRequestPtr &req,
+        [](const HttpRequestPtr &,
            std::function<void(const HttpResponsePtr &)> &&callback,
            const std::string &name) {
             auto resp = HttpResponse::newHttpResponse();

--- a/examples/jsonstore/main.cc
+++ b/examples/jsonstore/main.cc
@@ -50,7 +50,7 @@ class JsonStore : public HttpController<JsonStore>
     ADD_METHOD_VIA_REGEX(JsonStore::updateItem, "/([a-f0-9]{64})/(.*)", Put);
     METHOD_LIST_END
 
-    void getToken(const HttpRequestPtr& req,
+    void getToken(const HttpRequestPtr&,
                   std::function<void(const HttpResponsePtr&)>&& callback)
     {
         std::string randomString = getRandomString(64);
@@ -60,7 +60,7 @@ class JsonStore : public HttpController<JsonStore>
         callback(HttpResponse::newHttpJsonResponse(std::move(res)));
     }
 
-    void getItem(const HttpRequestPtr& req,
+    void getItem(const HttpRequestPtr&,
                  std::function<void(const HttpResponsePtr&)>&& callback,
                  const std::string& token,
                  const std::string& path)
@@ -163,7 +163,7 @@ class JsonStore : public HttpController<JsonStore>
         }
     }
 
-    void deleteItem(const HttpRequestPtr& req,
+    void deleteItem(const HttpRequestPtr&,
                     std::function<void(const HttpResponsePtr&)>&& callback,
                     const std::string& token)
     {

--- a/examples/websocket_client/WebSocketClient.cc
+++ b/examples/websocket_client/WebSocketClient.cc
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
     req->setPath(path);
 
     wsPtr->setMessageHandler([](const std::string &message,
-                                const WebSocketClientPtr &wsPtr,
+                                const WebSocketClientPtr &,
                                 const WebSocketMessageType &type) {
         std::string messageType = "Unknown";
         if (type == WebSocketMessageType::Text)
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
         LOG_INFO << "new message (" << messageType << "): " << message;
     });
 
-    wsPtr->setConnectionClosedHandler([](const WebSocketClientPtr &wsPtr) {
+    wsPtr->setConnectionClosedHandler([](const WebSocketClientPtr &) {
         LOG_INFO << "WebSocket connection closed!";
     });
 
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
     wsPtr->connectToServer(
         req,
         [](ReqResult r,
-           const HttpResponsePtr &resp,
+           const HttpResponsePtr &,
            const WebSocketClientPtr &wsPtr) {
             if (r != ReqResult::Ok)
             {

--- a/lib/inc/drogon/HttpRequest.h
+++ b/lib/inc/drogon/HttpRequest.h
@@ -38,7 +38,7 @@ using HttpRequestPtr = std::shared_ptr<HttpRequest>;
  * type object. Users must specialize the template for a particular type.
  */
 template <typename T>
-T fromRequest(const HttpRequest &req)
+T fromRequest(const HttpRequest &)
 {
     LOG_ERROR << "You must specialize the fromRequest template for the type of "
               << DrClassMap::demangle(typeid(T).name());


### PR DESCRIPTION
While utilizing drogon, I found that there were some templated functions that would trigger -Wunused-parameter when instantiated.  This PR hopes to remedy that (and keep it fixed) by simply adding the same warnings used for the drogon library to the example executables.  

The main 'fix' is to lib/inc/drogon/HttpRequest.h, but adding these warnings also necessitated some minor parameter removals from the example code.

