### PR TITLE
Update CacheFile.cc for >2GB files support on Windows

### DIFF
--- a/lib/src/CacheFile.cc
+++ b/lib/src/CacheFile.cc
@@ -66,7 +66,11 @@ void CacheFile::append(const char *data, size_t length)
 size_t CacheFile::length()
 {
     if (file_)
+#ifdef _WIN32
+        return _ftelli64(file_);
+#else
         return ftell(file_);
+#endif
     return 0;
 }
 


### PR DESCRIPTION
On Windows, ftell returns a 32 bits signed integer.
On Windows we had to use _ftelli64 to return a signed 64 bits integer.