### PR TITLE
Error on failing to create view from CSP

### DIFF
--- a/drogon_ctl/create_view.cc
+++ b/drogon_ctl/create_view.cc
@@ -291,7 +291,8 @@ void create_view::createViewFiles(std::vector<std::string> &cspFileNames)
     for (auto const &file : cspFileNames)
     {
         std::cout << "create view:" << file << std::endl;
-        createViewFile(file);
+        if (createViewFile(file) != 0)
+            exit(1);
     }
 }
 int create_view::createViewFile(const std::string &script_filename)


### PR DESCRIPTION
This patch makes the `drogon_ctl create view` command exit with status code 1 when it failed to create a view from CSP. I've made some stupid mistakes in my scripts recently. Then spent hours tracking why no view is generated even though the status code is 0. This PR makes that issue disappear.